### PR TITLE
Export targets for outside project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ install_manifest.txt
 
 # ccls
 .ccls
+.ccls-cache
 compile_commands.json
 
 src/base/Base.h.gch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,4 +471,5 @@ set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION /usr/local)
 include(CPack)
 
 add_subdirectory(src)
+add_subdirectory(exports)
 

--- a/cmake/FindDoubleConversion.cmake
+++ b/cmake/FindDoubleConversion.cmake
@@ -13,7 +13,7 @@
 #  DoubleConversion_INCLUDE_DIR      The double-conversion includes directories.
 #  DoubleConversion_LIBRARY          The double-conversion library.
 
-find_path(DoubleConversion_INCLUDE_DIR NAMES double-conversion.h)
+find_path(DoubleConversion_INCLUDE_DIR NAMES double-conversion/double-conversion.h)
 find_library(DoubleConversion_LIBRARY NAMES libdouble-conversion.a)
 
 if(DoubleConversion_INCLUDE_DIR AND DoubleConversion_LIBRARY)

--- a/exports/CMakeLists.txt
+++ b/exports/CMakeLists.txt
@@ -1,0 +1,48 @@
+# Copyright (c) 2020 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License,
+# attached with Common Clause Condition 1.0, found in the LICENSES directory.
+#
+
+export(
+  TARGETS
+    # base
+    base_obj
+    # clients
+    graph_client_obj
+    meta_client_obj
+    file_based_cluster_id_man_obj
+    graph_storage_client_obj
+    general_storage_client_obj
+    # concurrent
+    concurrent_obj
+    # conf
+    conf_obj
+    # datatypes
+    datatypes_obj
+    # fs
+    fs_obj
+    # hdfs
+    hdfs_helper_obj
+    # http
+    http_client_obj
+    # interface
+    # meta
+    meta_obj
+    # network
+    network_obj
+    # process
+    process_obj
+    # stats
+    stats_obj
+    # thread
+    thread_obj
+    # thrift
+    thrift_obj
+    # time
+    time_obj
+    # webservice
+    ws_common_obj
+    ws_obj
+  FILE nebula-common-exports.cmake
+  )


### PR DESCRIPTION
Usage:
```cmake
include(ExternalProject)
ExternalProject_Add(
    common
    PREFIX modules
    SOURCE_DIR modules/common
    GIT_REPOSITORY ${NEBULA_COMMON_REPO_URL}
    GIT_SHALLOW true
    GIT_PROGRESS true
    GIT_TAG ${NEBULA_COMMON_REPO_TAG}
    CMAKE_ARGS
        -DNEBULA_THIRDPARTY_ROOT=${NEBULA_THIRDPARTY_ROOT}
        -DNEBULA_OTHER_ROOT=${NEBULA_OTHER_ROOT}
        -DENABLE_JEMALLOC=${ENABLE_JEMALLOC}
        -DENABLE_NATIVE=${ENABLE_NATIVE}
        -DENABLE_CCACHE=${ENABLE_CCACHE}
        -DENABLE_TESTING=false
    INSTALL_COMMAND ""
    BUILD_IN_SOURCE true
)

ExternalProject_Get_Property(common SOURCE_DIR)
include(${SOURCE_DIR}/exports/nebula-common-exports.cmake)
```