### PR TITLE
Make Status constructor public

### DIFF
--- a/src/base/Status.h
+++ b/src/base/Status.h
@@ -103,6 +103,10 @@ public:
         return Status();
     }
 
+    static Status error(folly::StringPiece msg) {
+        return Status(Code::kError, msg);
+    }
+
 #define STATUS_GENERATOR(ERROR)                         \
     static Status ERROR() {                             \
         return Status(k##ERROR, "");                    \


### PR DESCRIPTION
Make Status constructor public for regular error type rather than defining the specified error constructor