### PR TITLE
Name conflicts with glibc 2.17

### DIFF
--- a/src/datatypes/Value.h
+++ b/src/datatypes/Value.h
@@ -35,7 +35,7 @@ enum class NullType {
     NaN      = 1,
     BAD_DATA = 2,
     BAD_TYPE = 3,
-    OVERFLOW = 4,
+    ERR_OVERFLOW = 4,
     UNKNOWN_PROP = 5,
 };
 


### PR DESCRIPTION
nebula-common compile failed under glibc-2.17 due to OVERFLOW is a macro in math.h.
We'd better rename it. 

