### PR TITLE
The shcema property is optional for schema, so avoid check if ttl_col…

### DIFF
--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -143,13 +143,13 @@ struct ColumnDef {
 }
 
 struct SchemaProp {
-    1: optional i64      ttl_duration,
-    2: optional binary   ttl_col,
+    1: i64      ttl_duration,
+    2: binary   ttl_col,
 }
 
 struct Schema {
-    1: list<ColumnDef> columns,
-    2: SchemaProp schema_prop,
+    1: list<ColumnDef>     columns,
+    2: optional SchemaProp schema_prop,
 }
 
 struct IdName {


### PR DESCRIPTION
…, ttl_duration either is set.