### PR TITLE
Add RETURN_IF_ERROR macro to simplify status handling

### DIFF
--- a/src/base/Status.h
+++ b/src/base/Status.h
@@ -198,6 +198,12 @@ inline std::ostream& operator<<(std::ostream &os, const Status &status) {
     return os << status.toString();
 }
 
+#define NG_RETURN_IF_ERROR(...)                                                                    \
+    do {                                                                                           \
+        ::nebula::Status _status = (__VA_ARGS__);                                                  \
+        if (UNLIKELY(!_status.ok())) return _status;                                               \
+    } while (0)
+
 }   // namespace nebula
 
 #endif  // COMMON_BASE_STATUS_H_


### PR DESCRIPTION
for example:

```cpp
// definition
Status foo();
Status bar();

// usage
Status foobar() {
  NG_RETURN_IF_ERROR(foo());
  NG_RETURN_IF_ERROR(bar());
  return Status::OK();
}
```