### PR TITLE
Fix shadow variable compile error and init schema manager after creation

### DIFF
--- a/src/expression/AliasPropertyExpression.h
+++ b/src/expression/AliasPropertyExpression.h
@@ -11,10 +11,10 @@
 
 namespace nebula {
 
-constexpr char INPUT_REF[]  = "$-";
-constexpr char VAR_REF[]    = "$";
-constexpr char SRC_REF[]    = "$^";
-constexpr char DST_REF[]    = "$$";
+constexpr char const kInputRef[]  = "$-";
+constexpr char const kVarRef[]    = "$";
+constexpr char const kSrcRef[]    = "$^";
+constexpr char const kDstRef[]    = "$$";
 
 // Alias.any_prop_name, i.e. EdgeName.any_prop_name
 class AliasPropertyExpression: public Expression {
@@ -57,7 +57,7 @@ class InputPropertyExpression final : public AliasPropertyExpression {
 public:
     explicit InputPropertyExpression(std::string* prop)
         : AliasPropertyExpression(Type::EXP_INPUT_PROPERTY,
-                                  new std::string(INPUT_REF),
+                                  new std::string(kInputRef),
                                   new std::string(""),
                                   prop) {}
 
@@ -85,7 +85,7 @@ public:
     VariablePropertyExpression(std::string* var,
                                std::string* prop)
         : AliasPropertyExpression(Type::EXP_VAR_PROPERTY,
-                                  new std::string(VAR_REF),
+                                  new std::string(kVarRef),
                                   var,
                                   prop) {}
 
@@ -113,7 +113,7 @@ public:
     SourcePropertyExpression(std::string* tag,
                              std::string* prop)
         : AliasPropertyExpression(Type::EXP_SRC_PROPERTY,
-                                  new std::string(SRC_REF),
+                                  new std::string(kSrcRef),
                                   tag,
                                   prop) {}
 
@@ -141,7 +141,7 @@ public:
     DestPropertyExpression(std::string* tag,
                            std::string* prop)
         : AliasPropertyExpression(Type::EXP_DST_PROPERTY,
-                                  new std::string(DST_REF),
+                                  new std::string(kDstRef),
                                   tag,
                                   prop) {}
 

--- a/src/meta/SchemaManager.cpp
+++ b/src/meta/SchemaManager.cpp
@@ -10,8 +10,10 @@
 namespace nebula {
 namespace meta {
 
-std::unique_ptr<SchemaManager> SchemaManager::create() {
-    return std::make_unique<ServerBasedSchemaManager>();
+std::unique_ptr<SchemaManager> SchemaManager::create(MetaClient *client) {
+    auto mgr = std::make_unique<ServerBasedSchemaManager>();
+    mgr->init(client);
+    return mgr;
 }
 
 }   // namespace meta

--- a/src/meta/SchemaManager.h
+++ b/src/meta/SchemaManager.h
@@ -15,11 +15,13 @@
 namespace nebula {
 namespace meta {
 
+class MetaClient;
+
 class SchemaManager {
 public:
     virtual ~SchemaManager() = default;
 
-    static std::unique_ptr<SchemaManager> create();
+    static std::unique_ptr<SchemaManager> create(MetaClient *client);
 
     virtual std::shared_ptr<const SchemaProviderIf>
     getTagSchema(GraphSpaceID space, TagID tag, SchemaVer ver = -1) = 0;


### PR DESCRIPTION
`INPUT_REF`/`DST_REF` will be defined in a generated source file by [the parser file](https://github.com/vesoft-inc-private/nebula/blob/d676dffc869f0897a5080d5df74e9105cdc9e44f/src/parser/parser.yy#L136).

the error detail is as follows:

```
In file included from scanner.lex:8:
In file included from /home/yee.yi/Workspace/vesoft-private/nebula/src/parser/GQLParser.h:11:
/home/yee.yi/Workspace/vesoft-private/nebula/build/src/parser/GraphParser.hpp:402:9: error: declaration shadows a variable in namespace 'nebula' [-Werror,-Wshadow]
        INPUT_REF = 432,
        ^
/home/yee.yi/Workspace/vesoft-private/nebula/modules/common/src/expression/AliasPropertyExpression.h:14:16: note: previous declaration is here
constexpr char INPUT_REF[]  = "$-";
               ^
In file included from scanner.lex:8:
In file included from /home/yee.yi/Workspace/vesoft-private/nebula/src/parser/GQLParser.h:11:
/home/yee.yi/Workspace/vesoft-private/nebula/build/src/parser/GraphParser.hpp:403:9: error: declaration shadows a variable in namespace 'nebula' [-Werror,-Wshadow]
        DST_REF = 433,
        ^
/home/yee.yi/Workspace/vesoft-private/nebula/modules/common/src/expression/AliasPropertyExpression.h:17:16: note: previous declaration is here
constexpr char DST_REF[]    = "$$";
               ^
In file included from scanner.lex:8:
In file included from /home/yee.yi/Workspace/vesoft-private/nebula/src/parser/GQLParser.h:11:
/home/yee.yi/Workspace/vesoft-private/nebula/build/src/parser/GraphParser.hpp:404:9: error: declaration shadows a variable in namespace 'nebula' [-Werror,-Wshadow]
        SRC_REF = 434,
        ^
/home/yee.yi/Workspace/vesoft-private/nebula/modules/common/src/expression/AliasPropertyExpression.h:16:16: note: previous declaration is here
constexpr char SRC_REF[]    = "$^";
               ^
3 errors generated.
```