### PR TITLE
invalid dest host addr may cause thrift manager core

### DIFF
--- a/src/network/NetworkUtils.cpp
+++ b/src/network/NetworkUtils.cpp
@@ -17,6 +17,8 @@ namespace network {
 
 static const int32_t kMaxHostNameLen = 256;
 
+
+// TODO(liuyu) this only works in ipv4
 std::string NetworkUtils::getHostname() {
     char hn[kMaxHostNameLen];
 

--- a/src/thrift/ThriftClientManager.inl
+++ b/src/thrift/ThriftClientManager.inl
@@ -32,7 +32,7 @@ std::shared_ptr<ClientType> ThriftClientManager<ClientType>::client(
     // Need to create a new client
     VLOG(2) << "There is no existing client to " << host << ", trying to create one";
     auto channel = apache::thrift::ReconnectingRequestChannel::newChannel(
-        *evb, [compatibility, &host, timeout] (folly::EventBase& eb) mutable {
+        *evb, [compatibility, host, timeout] (folly::EventBase& eb) mutable {
             static thread_local int connectionCount = 0;
 
             /*


### PR DESCRIPTION
thriftClientManager :: newChannel capture host addr by reference,

this will lead to core dump if retry happens

change to capture by value