### PR TITLE
Refactor static constant values

### DIFF
--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -80,6 +80,15 @@ namespace nebula {
 
 constexpr auto EPSILON = 1e-8;
 
+const Value Value::kEmpty;
+const Value Value::kNullValue(NullType::__NULL__);
+const Value Value::kNullNaN(NullType::NaN);
+const Value Value::kNullBadData(NullType::BAD_DATA);
+const Value Value::kNullBadType(NullType::BAD_TYPE);
+const Value Value::kNullOverflow(NullType::ERR_OVERFLOW);
+const Value Value::kNullUnknownProp(NullType::UNKNOWN_PROP);
+const Value Value::kNullDivByZero(NullType::DIV_BY_ZERO);
+
 Value::Value(Value&& rhs) : type_(Value::Type::__EMPTY__) {
     if (this == &rhs) { return; }
     if (rhs.type_ == Type::__EMPTY__) { return; }

--- a/src/common/datatypes/Value.h
+++ b/src/common/datatypes/Value.h
@@ -44,6 +44,15 @@ enum class NullType {
 
 
 struct Value {
+    static const Value kEmpty;
+    static const Value kNullValue;
+    static const Value kNullNaN;
+    static const Value kNullBadData;
+    static const Value kNullBadType;
+    static const Value kNullOverflow;
+    static const Value kNullUnknownProp;
+    static const Value kNullDivByZero;
+
     friend class apache::thrift::Cpp2Ops<Value, void>;
 
     enum class Type : uint8_t {
@@ -262,7 +271,6 @@ struct Value {
     DataSet& mutableDataSet();
 
     static const Value& null() noexcept {
-        static const Value kNullValue(NullType::__NULL__);
         return kNullValue;
     }
 
@@ -359,15 +367,6 @@ private:
 void swap(Value& a, Value& b);
 
 std::ostream& operator<<(std::ostream& os, const Value::Type& type);
-
-static const Value kEmpty;
-static const Value kNullValue(NullType::__NULL__);
-static const Value kNullNan(NullType::NaN);
-static const Value kNullBadData(NullType::BAD_DATA);
-static const Value kNullBadType(NullType::BAD_TYPE);
-static const Value kNullOverflow(NullType::ERR_OVERFLOW);
-static const Value kNullUnknownProp(NullType::UNKNOWN_PROP);
-static const Value kNullDivByZero(NullType::DIV_BY_ZERO);
 
 // Arithmetic operations
 Value operator+(const Value& lhs, const Value& rhs);

--- a/src/common/expression/VariableExpression.cpp
+++ b/src/common/expression/VariableExpression.cpp
@@ -15,8 +15,8 @@ const Value& VariableExpression::eval(ExpressionContext& ctx) {
 const Value& VersionedVariableExpression::eval(ExpressionContext& ctx) {
     if (version_ != nullptr) {
         auto version = version_->eval(ctx);
-        if (UNLIKELY(version.type() != Value::Type::INT)) {
-            return kNullBadType;
+        if (UNLIKELY(!version.isInt())) {
+            return Value::kNullBadType;
         }
         auto ver = version.getInt();
         return ctx.getVersionedVar(*var_, ver);

--- a/src/common/expression/test/CMakeLists.txt
+++ b/src/common/expression/test/CMakeLists.txt
@@ -3,6 +3,11 @@
 # This source code is licensed under Apache 2.0 License,
 # attached with Common Clause Condition 1.0, found in the LICENSES directory.
 
+nebula_add_library(
+    expr_ctx_mock_obj OBJECT
+    ExpressionContextMock.cpp
+    )
+
 nebula_add_test(
     NAME
         expression_test
@@ -12,6 +17,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:expression_obj>
         $<TARGET_OBJECTS:datatypes_obj>
         $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:expr_ctx_mock_obj>
     LIBRARIES
         gtest
         gtest_main
@@ -27,6 +33,7 @@ nebula_add_executable(
         $<TARGET_OBJECTS:expression_obj>
         $<TARGET_OBJECTS:datatypes_obj>
         $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:expr_ctx_mock_obj>
     LIBRARIES
         follybenchmark
         boost_regex
@@ -34,7 +41,6 @@ nebula_add_executable(
 )
 
 nebula_add_test(
-    NAME
     NAME expression_encode_decode_test
     SOURCES EncodeDecodeTest.cpp
     OBJECTS

--- a/src/common/expression/test/ExpressionContextMock.cpp
+++ b/src/common/expression/test/ExpressionContextMock.cpp
@@ -1,0 +1,32 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "common/expression/test/ExpressionContextMock.h"
+
+namespace nebula {
+
+std::unordered_map<std::string, Value> ExpressionContextMock::vals_ = {
+    {"empty", Value()},
+    {"null", Value(NullType::NaN)},
+    {"bool_true", Value(true)},
+    {"bool_false", Value(false)},
+    {"int", Value(1)},
+    {"float", Value(1.1)},
+    {"string16", Value(std::string(16, 'a'))},
+    {"string32", Value(std::string(32, 'a'))},
+    {"string64", Value(std::string(64, 'a'))},
+    {"string128", Value(std::string(128, 'a'))},
+    {"string256", Value(std::string(256, 'a'))},
+    {"string4096", Value(std::string(4096, 'a'))},
+    {"list", Value(List(std::vector<Value>(16, Value("aaaa"))))},
+    {"list_of_list",
+     Value(List(std::vector<Value>(16, Value(List(std::vector<Value>(16, Value("aaaa")))))))},
+    {"var_int", Value(1)},
+    {"versioned_var", Value(List(std::vector<Value>{1, 2, 3, 4, 5, 6, 7, 8}))},
+    {"cnt", Value(1)},
+};
+
+}   // namespace nebula

--- a/src/common/expression/test/ExpressionContextMock.h
+++ b/src/common/expression/test/ExpressionContextMock.h
@@ -9,13 +9,13 @@
 #include "common/context/ExpressionContext.h"
 
 namespace nebula {
-using nebula::Value;
+
 class ExpressionContextMock final : public ExpressionContext {
 public:
     const Value& getVar(const std::string& var) const override {
         auto found = vals_.find(var);
         if (found == vals_.end()) {
-            return kNullValue;
+            return Value::kNullValue;
         } else {
             if (var == "versioned_var") {
                 return found->second.getList().values.back();
@@ -28,14 +28,14 @@ public:
                                  int64_t version) const override {
         auto found = vals_.find(var);
         if (found == vals_.end()) {
-            return kNullValue;
+            return Value::kNullValue;
         } else {
             if (found->second.type() != Value::Type::LIST) {
-                return kNullValue;
+                return Value::kNullValue;
             }
             auto size = found->second.getList().size();
             if (size <= static_cast<size_t>(std::abs(version))) {
-                return kNullValue;
+                return Value::kNullValue;
             }
             if (version <= 0) {
                 return found->second.getList()[std::abs(version)];
@@ -50,7 +50,7 @@ public:
         UNUSED(var);
         auto found = vals_.find(prop);
         if (found == vals_.end()) {
-            return kNullValue;
+            return Value::kNullValue;
         } else {
             return found->second;
         }
@@ -61,7 +61,7 @@ public:
         UNUSED(edgeType);
         auto found = vals_.find(prop);
         if (found == vals_.end()) {
-            return kNullValue;
+            return Value::kNullValue;
         } else {
             return found->second;
         }
@@ -72,7 +72,7 @@ public:
         UNUSED(tag);
         auto found = vals_.find(prop);
         if (found == vals_.end()) {
-            return kNullValue;
+            return Value::kNullValue;
         } else {
             return found->second;
         }
@@ -83,7 +83,7 @@ public:
         UNUSED(tag);
         auto found = vals_.find(prop);
         if (found == vals_.end()) {
-            return kNullValue;
+            return Value::kNullValue;
         } else {
             return found->second;
         }
@@ -92,7 +92,7 @@ public:
     const Value& getInputProp(const std::string& prop) const override {
         auto found = vals_.find(prop);
         if (found == vals_.end()) {
-            return kNullValue;
+            return Value::kNullValue;
         } else {
             return found->second;
         }
@@ -107,25 +107,4 @@ private:
     static std::unordered_map<std::string, Value>      vals_;
 };
 
-std::unordered_map<std::string, Value>
-    ExpressionContextMock::vals_ = {
-    {"empty", Value()},
-    {"null", Value(NullType::NaN)},
-    {"bool_true", Value(true)},
-    {"bool_false", Value(false)},
-    {"int", Value(1)},
-    {"float", Value(1.1)},
-    {"string16", Value(std::string(16, 'a'))},
-    {"string32", Value(std::string(32, 'a'))},
-    {"string64", Value(std::string(64, 'a'))},
-    {"string128", Value(std::string(128, 'a'))},
-    {"string256", Value(std::string(256, 'a'))},
-    {"string4096", Value(std::string(4096, 'a'))},
-    {"list", Value(List(std::vector<Value>(16, Value("aaaa"))))},
-    {"list_of_list", Value(List(std::vector<Value>(16,
-                        Value(List(std::vector<Value>(16, Value("aaaa")))))))},
-    {"var_int", Value(1)},
-    {"versioned_var", Value(List(std::vector<Value>{1, 2, 3, 4, 5, 6, 7, 8}))},
-    {"cnt", Value(1)},
-};
 }  // namespace nebula


### PR DESCRIPTION
The `kEmpty` representing an empty value is too general name for usage. Prefer to rename it to  `Value::kEmpty`.