### PR TITLE
Suppress TLS-related memory leak reported by LSAN

### DIFF
--- a/src/common/base/SanitizerOptions.cpp
+++ b/src/common/base/SanitizerOptions.cpp
@@ -55,6 +55,7 @@ const char* __lsan_default_suppressions() {
     // NOTE  Don't add extra spaces around the suppression patterns, unless you intend to.
     return ""
            "leak:folly::SingletonVault::destroyInstances\n"
+           "leak:__cxa_thread_atexit\n"
            "";
 }
 


### PR DESCRIPTION
As title.

FYI.
```
=================================================================
==23242==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x531257 in operator new(unsigned long, std::nothrow_t const&) /usr/src/nebula-package/toolset-build/source/llvm-9.0.0/projects/compiler-rt/lib/asan/asan_new_delete.cc:105:3
    #1 0x2700f0d in __cxa_thread_atexit (/home/dutor.hou/Wdir/nebula-2.0/build/bin/test/schema_test+0x2700f0d)
    #2 0x2367c77 in folly::SingletonThreadLocal<std::shared_ptr<folly::RequestContext>, folly::detail::DefaultTag, folly::detail::DefaultMake<std::shared_ptr<folly::RequestContext> >, void>::getSlow(folly::SingletonThreadLocal<std::shared_ptr<folly::RequestContext>, folly::detail::DefaultTag, folly::detail::DefaultMake<std::shared_ptr<folly::RequestContext> >, void>::Wrapper*&) (/home/dutor.hou/Wdir/nebula-2.0/build/bin/test/schema_test+0x2367c77)
    #3 0x235a1c5 in folly::EventBase::runInEventBaseThread(folly::Function<void ()>) (/home/dutor.hou/Wdir/nebula-2.0/build/bin/test/schema_test+0x235a1c5)
    #4 0x22e8e54 in folly::IOThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>) (/home/dutor.hou/Wdir/nebula-2.0/build/bin/test/schema_test+0x22e8e54)
    #5 0x22f3ff6 in void folly::detail::function::FunctionTraits<void ()>::callBig<std::_Bind<void (folly::ThreadPoolExecutor::* (folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)> >(folly::detail::function::Data&) (/home/dutor.hou/Wdir/nebula-2.0/build/bin/test/schema_test+0x22f3ff6)
    #6 0x5ad2bb in folly::detail::function::FunctionTraits<void ()>::operator()() /opt/vesoft/third-party/include/folly/Function.h:328:12
    #7 0x5ad219 in folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()::operator()() /opt/vesoft/third-party/include/folly/executors/thread_factory/NamedThreadFactory.h:40:11
    #8 0x5ad09c in void std::__invoke_impl<void, folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>(std::__invoke_other, folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()&&) /opt/vesoft/toolset/clang/9.0.0/lib/gcc/x86_64-vesoft-linux/9.2.0/../../../../include/c++/9.2.0/bits/invoke.h:60:14
    #9 0x5ad02c in std::__invoke_result<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>::type std::__invoke<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>(folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()&&) /opt/vesoft/toolset/clang/9.0.0/lib/gcc/x86_64-vesoft-linux/9.2.0/../../../../include/c++/9.2.0/bits/invoke.h:95:14
    #10 0x5ad004 in void std::thread::_Invoker<std::tuple<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /opt/vesoft/toolset/clang/9.0.0/lib/gcc/x86_64-vesoft-linux/9.2.0/../../../../include/c++/9.2.0/thread:244:13
    #11 0x5acfd4 in std::thread::_Invoker<std::tuple<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()> >::operator()() /opt/vesoft/toolset/clang/9.0.0/lib/gcc/x86_64-vesoft-linux/9.2.0/../../../../include/c++/9.2.0/thread:251:11
    #12 0x5ace5d in std::thread::_State_impl<std::thread::_Invoker<std::tuple<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()> > >::_M_run() /opt/vesoft/toolset/clang/9.0.0/lib/gcc/x86_64-vesoft-linux/9.2.0/../../../../include/c++/9.2.0/thread:195:13
    #13 0x273fa4f in execute_native_thread_routine (/home/dutor.hou/Wdir/nebula-2.0/build/bin/test/schema_test+0x273fa4f)
    #14 0x7f2661a6b4bf in start_thread (/usr/lib64/libpthread.so.0+0x84bf)
    #15 0x7f266198f552 in __GI___clone (/usr/lib64/libc.so.6+0xfc552)

SUMMARY: AddressSanitizer: 24 byte(s) leaked in 1 allocation(s).
```