### PR TITLE
Remove offline when building index

### DIFF
--- a/src/common/clients/meta/MetaClient.cpp
+++ b/src/common/clients/meta/MetaClient.cpp
@@ -1526,12 +1526,10 @@ MetaClient::listTagIndexes(GraphSpaceID spaceID) {
 
 folly::Future<StatusOr<bool>>
 MetaClient::rebuildTagIndex(GraphSpaceID spaceID,
-                            std::string name,
-                            bool isOffline) {
+                            std::string name) {
     cpp2::RebuildIndexReq req;
     req.set_space_id(spaceID);
     req.set_index_name(std::move(name));
-    req.set_is_offline(isOffline);
 
     folly::Promise<StatusOr<bool>> promise;
     auto future = promise.getFuture();
@@ -1746,12 +1744,10 @@ StatusOr<EdgeSchemas> MetaClient::getAllVerEdgeSchema(GraphSpaceID spaceId) {
 
 folly::Future<StatusOr<bool>>
 MetaClient::rebuildEdgeIndex(GraphSpaceID spaceID,
-                             std::string name,
-                             bool isOffline) {
+                             std::string name) {
     cpp2::RebuildIndexReq req;
     req.set_space_id(spaceID);
     req.set_index_name(std::move(name));
-    req.set_is_offline(isOffline);
 
     folly::Promise<StatusOr<bool>> promise;
     auto future = promise.getFuture();

--- a/src/common/clients/meta/MetaClient.h
+++ b/src/common/clients/meta/MetaClient.h
@@ -302,7 +302,7 @@ public:
     listTagIndexes(GraphSpaceID spaceId);
 
     folly::Future<StatusOr<bool>>
-    rebuildTagIndex(GraphSpaceID spaceID, std::string name, bool isOffline);
+    rebuildTagIndex(GraphSpaceID spaceID, std::string name);
 
     folly::Future<StatusOr<std::vector<cpp2::IndexStatus>>>
     listTagIndexStatus(GraphSpaceID spaceId);
@@ -325,7 +325,7 @@ public:
     listEdgeIndexes(GraphSpaceID spaceId);
 
     folly::Future<StatusOr<bool>>
-    rebuildEdgeIndex(GraphSpaceID spaceId, std::string name, bool isOffline);
+    rebuildEdgeIndex(GraphSpaceID spaceId, std::string name);
 
     folly::Future<StatusOr<std::vector<cpp2::IndexStatus>>>
     listEdgeIndexStatus(GraphSpaceID spaceId);

--- a/src/common/interface/meta.thrift
+++ b/src/common/interface/meta.thrift
@@ -642,7 +642,6 @@ struct ListEdgeIndexesResp {
 struct RebuildIndexReq {
     1: common.GraphSpaceID space_id,
     2: binary              index_name,
-    3: bool                is_offline,
 }
 
 struct CreateUserReq {


### PR DESCRIPTION
Currently we don't distinguish the offline building index and online building index. So try to remove this property in the protocol.