### PR TITLE
fix get edge latest schema from metaclient localcache 

### DIFF
--- a/src/common/clients/meta/MetaClient.cpp
+++ b/src/common/clients/meta/MetaClient.cpp
@@ -346,7 +346,7 @@ bool MetaClient::loadSchemas(GraphSpaceID spaceId,
         if (edgeIt.edge_type != lastEdgeType) {
             // init schema vector, since schema version is zero-based, need to add one
             edgeSchemas[edgeIt.edge_type].resize(schema->getVersion() + 1);
-            lastTagId = edgeIt.edge_type;
+            lastEdgeType = edgeIt.edge_type;
         }
         edgeSchemas[edgeIt.edge_type][schema->getVersion()] = std::move(schema);
         edgeNameTypeMap.emplace(std::make_pair(spaceId, edgeIt.edge_name), edgeIt.edge_type);


### PR DESCRIPTION
Cannot get the latest edge schema after when alter edge

the case as follows:
```
CREATE EDGE like(likeness double);
ALTER EDGE like ADD (new_field string default "123");
```

Both insert and update will fail:
```
UPSERT EDGE ON like "1"->"300" SET likeness = 3.0, new_field = "321"
INSERT EDGE like (likeness, new_field) VALUES "1"->"400":(3.0,"321");
```

