### PR TITLE
Fix target export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ include(GitInfoConfig)
 include(NebulaCMakeMacros)
 include(NebulaCustomTargets)
 
+# Remove the target exporting file
+file(REMOVE ${CMAKE_BINARY_DIR}/${PACKAGE_NAME}-config.cmake)
+
 # For simplicity, we make all ordinary libraries depend on the compile-time generated files,
 # including the precompiled header, a.k.a Base.h.gch, and thrift headers.
 macro(nebula_add_library name type)


### PR DESCRIPTION
`export`  keeps appending to the old target exporting file. This causes new added source/object files unable to be linked by dependent project.