### PR TITLE
Add AttributeExpression

### DIFF
--- a/src/common/context/ExpressionContext.h
+++ b/src/common/context/ExpressionContext.h
@@ -55,6 +55,12 @@ public:
     // Get the specified property from the input, such as $-.prop_name
     virtual const Value& getInputProp(const std::string& prop) const = 0;
 
+    // Get Vertex
+    virtual Value getVertex() const = 0;
+
+    // Get Edge
+    virtual Value getEdge() const = 0;
+
     virtual void setVar(const std::string& var, Value val) = 0;
 };
 

--- a/src/common/expression/AttributeExpression.cpp
+++ b/src/common/expression/AttributeExpression.cpp
@@ -1,0 +1,53 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "common/expression/AttributeExpression.h"
+#include "common/datatypes/Map.h"
+#include "common/datatypes/Edge.h"
+#include "common/datatypes/Vertex.h"
+
+namespace nebula {
+
+const Value& AttributeExpression::eval(ExpressionContext &ctx) {
+    auto &lvalue = left()->eval(ctx);
+    auto &rvalue = right()->eval(ctx);
+    DCHECK(rvalue.isStr());
+
+    // TODO(dutor) Take care of the builtin properties, _src, _vid, _type, etc.
+    if (lvalue.isMap()) {
+        return lvalue.getMap().at(rvalue.getStr());
+    } else if (lvalue.isVertex()) {
+        for (auto &tag : lvalue.getVertex().tags) {
+            auto iter = tag.props.find(rvalue.getStr());
+            if (iter != tag.props.end()) {
+                return iter->second;
+            }
+        }
+        return Value::kNullValue;
+    } else if (lvalue.isEdge()) {
+        auto iter = lvalue.getEdge().props.find(rvalue.getStr());
+        if (iter == lvalue.getEdge().props.end()) {
+            return Value::kNullValue;
+        }
+        return iter->second;
+    }
+
+    return Value::kNullBadType;
+}
+
+
+std::string AttributeExpression::toString() const {
+    CHECK(right()->kind() == Kind::kLabel || right()->kind() == Kind::kConstant);
+    std::string buf;
+    buf.reserve(256);
+    buf += left()->toString();
+    buf += '.';
+    buf += right()->toString();
+
+    return buf;
+}
+
+}   // namespace nebula

--- a/src/common/expression/AttributeExpression.h
+++ b/src/common/expression/AttributeExpression.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef COMMON_EXPRESSION_ATTRIBUTEEXPRESSION_H_
+#define COMMON_EXPRESSION_ATTRIBUTEEXPRESSION_H_
+
+#include "common/expression/BinaryExpression.h"
+
+namespace nebula {
+
+// <expr>.label
+class AttributeExpression final : public BinaryExpression {
+public:
+    explicit AttributeExpression(Expression *lhs = nullptr,
+                                 Expression *rhs = nullptr)
+        : BinaryExpression(Kind::kAttribute, lhs, rhs) {}
+
+    const Value& eval(ExpressionContext &ctx) override;
+
+    std::string toString() const override;
+};
+
+}   // namespace nebula
+
+#endif  // COMMON_EXPRESSION_ATTRIBUTEEXPRESSION_H_

--- a/src/common/expression/CMakeLists.txt
+++ b/src/common/expression/CMakeLists.txt
@@ -14,12 +14,16 @@ nebula_add_library(
     LogicalExpression.cpp
     TypeCastingExpression.cpp
     FunctionCallExpression.cpp
-    SymbolPropertyExpression.cpp
+    PropertyExpression.cpp
     UUIDExpression.cpp
     VariableExpression.cpp
     ContainerExpression.cpp
     SubscriptExpression.cpp
+    AttributeExpression.cpp
+    LabelAttributeExpression.cpp
     LabelExpression.cpp
+    VertexExpression.cpp
+    EdgeExpression.cpp
 )
 
 nebula_add_subdirectory(test)

--- a/src/common/expression/EdgeExpression.cpp
+++ b/src/common/expression/EdgeExpression.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019 vesoft inc. All rights reserved.
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.

--- a/src/common/expression/EdgeExpression.cpp
+++ b/src/common/expression/EdgeExpression.cpp
@@ -1,0 +1,16 @@
+/* Copyright (c) 2019 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "common/expression/EdgeExpression.h"
+
+namespace nebula {
+
+const Value& EdgeExpression::eval(ExpressionContext &ctx) {
+    result_ = ctx.getEdge();
+    return result_;
+}
+
+}   // namespace nebula

--- a/src/common/expression/EdgeExpression.h
+++ b/src/common/expression/EdgeExpression.h
@@ -1,0 +1,47 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef COMMON_EXPRESSION_EDGEEXPRESSION_H_
+#define COMMON_EXPRESSION_EDGEEXPRESSION_H_
+
+#include "common/expression/Expression.h"
+
+namespace nebula {
+
+/**
+ * This is an internal type of expression to denote a Edge value.
+ * It has no corresponding rules in parser.
+ * It is generated from LabelExpression during semantic analysis
+ * and expression rewrite.
+ */
+class EdgeExpression final : public Expression {
+public:
+    EdgeExpression() : Expression(Kind::kEdge) {}
+
+    const Value& eval(ExpressionContext &ctx) override;
+
+    std::string toString() const override {
+        return "EDGE";
+    }
+
+    bool operator==(const Expression &expr) const override {
+        return kind() == expr.kind();
+    }
+
+private:
+    void writeTo(Encoder &encoder) const override {
+        encoder << kind();
+    }
+
+    void resetFrom(Decoder&) override {}
+
+private:
+    Value                                   result_;
+};
+
+}   // namespace nebula
+
+#endif  // COMMON_EXPRESSION_EDGEEXPRESSION_H_

--- a/src/common/expression/Expression.cpp
+++ b/src/common/expression/Expression.cpp
@@ -7,19 +7,23 @@
 #include "common/expression/Expression.h"
 #include <thrift/lib/cpp2/protocol/Serializer.h>
 #include "common/datatypes/ValueOps.h"
-#include "common/expression/SymbolPropertyExpression.h"
+#include "common/expression/PropertyExpression.h"
 #include "common/expression/ArithmeticExpression.h"
 #include "common/expression/ConstantExpression.h"
 #include "common/expression/FunctionCallExpression.h"
 #include "common/expression/LogicalExpression.h"
 #include "common/expression/RelationalExpression.h"
 #include "common/expression/SubscriptExpression.h"
+#include "common/expression/AttributeExpression.h"
+#include "common/expression/LabelAttributeExpression.h"
 #include "common/expression/TypeCastingExpression.h"
 #include "common/expression/UUIDExpression.h"
 #include "common/expression/UnaryExpression.h"
 #include "common/expression/VariableExpression.h"
 #include "common/expression/ContainerExpression.h"
 #include "common/expression/LabelExpression.h"
+#include "common/expression/VertexExpression.h"
+#include "common/expression/EdgeExpression.h"
 
 namespace nebula {
 
@@ -297,6 +301,16 @@ std::unique_ptr<Expression> Expression::decode(Expression::Decoder& decoder) {
             exp->resetFrom(decoder);
             return exp;
         }
+        case Expression::Kind::kAttribute: {
+            exp = std::make_unique<AttributeExpression>();
+            exp->resetFrom(decoder);
+            return exp;
+        }
+        case Expression::Kind::kLabelAttribute: {
+            exp = std::make_unique<LabelAttributeExpression>();
+            exp->resetFrom(decoder);
+            return exp;
+        }
         case Expression::Kind::kLogicalAnd: {
             exp = std::make_unique<LogicalExpression>(Expression::Kind::kLogicalAnd);
             exp->resetFrom(decoder);
@@ -319,11 +333,6 @@ std::unique_ptr<Expression> Expression::decode(Expression::Decoder& decoder) {
         }
         case Expression::Kind::kFunctionCall: {
             exp = std::make_unique<FunctionCallExpression>();
-            exp->resetFrom(decoder);
-            return exp;
-        }
-        case Expression::Kind::kSymProperty: {
-            exp = std::make_unique<SymbolPropertyExpression>();
             exp->resetFrom(decoder);
             return exp;
         }
@@ -374,6 +383,16 @@ std::unique_ptr<Expression> Expression::decode(Expression::Decoder& decoder) {
         }
         case Expression::Kind::kEdgeDst: {
             exp = std::make_unique<EdgeDstIdExpression>();
+            exp->resetFrom(decoder);
+            return exp;
+        }
+        case Expression::Kind::kVertex: {
+            exp = std::make_unique<VertexExpression>();
+            exp->resetFrom(decoder);
+            return exp;
+        }
+        case Expression::Kind::kEdge: {
+            exp = std::make_unique<EdgeExpression>();
             exp->resetFrom(decoder);
             return exp;
         }
@@ -480,6 +499,12 @@ std::ostream& operator<<(std::ostream& os, Expression::Kind kind) {
         case Expression::Kind::kSubscript:
             os << "Subscript";
             break;
+        case Expression::Kind::kAttribute:
+            os << "Attribute";
+            break;
+        case Expression::Kind::kLabelAttribute:
+            os << "LabelAttribute";
+            break;
         case Expression::Kind::kLogicalAnd:
             os << "LogicalAnd";
             break;
@@ -494,9 +519,6 @@ std::ostream& operator<<(std::ostream& os, Expression::Kind kind) {
             break;
         case Expression::Kind::kFunctionCall:
             os << "FunctionCall";
-            break;
-        case Expression::Kind::kSymProperty:
-            os << "SymbolProp";
             break;
         case Expression::Kind::kEdgeProperty:
             os << "EdgeProp";
@@ -527,6 +549,12 @@ std::ostream& operator<<(std::ostream& os, Expression::Kind kind) {
             break;
         case Expression::Kind::kEdgeDst:
             os << "EdgeDst";
+            break;
+        case Expression::Kind::kVertex:
+            os << "Vertex";
+            break;
+        case Expression::Kind::kEdge:
+            os << "Edge";
             break;
         case Expression::Kind::kUUID:
             os << "UUID";

--- a/src/common/expression/Expression.h
+++ b/src/common/expression/Expression.h
@@ -40,6 +40,8 @@ public:
         kRelNotIn,
         kContains,
         kSubscript,
+        kAttribute,
+        kLabelAttribute,
 
         kLogicalAnd,
         kLogicalOr,
@@ -49,7 +51,6 @@ public:
 
         kFunctionCall,
 
-        kSymProperty,
         kTagProperty,
         kEdgeProperty,
         kInputProperty,
@@ -60,6 +61,8 @@ public:
         kEdgeType,
         kEdgeRank,
         kEdgeDst,
+        kVertex,
+        kEdge,
 
         kUUID,
 

--- a/src/common/expression/LabelAttributeExpression.cpp
+++ b/src/common/expression/LabelAttributeExpression.cpp
@@ -9,8 +9,6 @@
 namespace nebula {
 
 std::string LabelAttributeExpression::toString() const {
-    CHECK(left()->kind() == Kind::kLabel);
-    CHECK(right()->kind() == Kind::kLabel);
     return left()->toString() + "." + right()->toString();
 }
 

--- a/src/common/expression/LabelAttributeExpression.cpp
+++ b/src/common/expression/LabelAttributeExpression.cpp
@@ -1,0 +1,17 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "common/expression/LabelAttributeExpression.h"
+
+namespace nebula {
+
+std::string LabelAttributeExpression::toString() const {
+    CHECK(left()->kind() == Kind::kLabel || left()->kind() == Kind::kConstant);
+    CHECK(right()->kind() == Kind::kLabel || right()->kind() == Kind::kConstant);
+    return left()->toString() + "." + right()->toString();
+}
+
+}   // namespace nebula

--- a/src/common/expression/LabelAttributeExpression.cpp
+++ b/src/common/expression/LabelAttributeExpression.cpp
@@ -9,8 +9,8 @@
 namespace nebula {
 
 std::string LabelAttributeExpression::toString() const {
-    CHECK(left()->kind() == Kind::kLabel || left()->kind() == Kind::kConstant);
-    CHECK(right()->kind() == Kind::kLabel || right()->kind() == Kind::kConstant);
+    CHECK(left()->kind() == Kind::kLabel);
+    CHECK(right()->kind() == Kind::kLabel);
     return left()->toString() + "." + right()->toString();
 }
 

--- a/src/common/expression/LabelAttributeExpression.h
+++ b/src/common/expression/LabelAttributeExpression.h
@@ -1,0 +1,39 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef COMMON_EXPRESSION_LABELATTRIBUTEEXPRESSION_H_
+#define COMMON_EXPRESSION_LABELATTRIBUTEEXPRESSION_H_
+
+#include "common/expression/BinaryExpression.h"
+#include "common/expression/LabelExpression.h"
+
+namespace nebula {
+
+// label.label
+class LabelAttributeExpression final : public BinaryExpression {
+public:
+    explicit LabelAttributeExpression(Expression *lhs = nullptr,
+                                      Expression *rhs = nullptr)
+        : BinaryExpression(Kind::kLabelAttribute, lhs, rhs) {}
+
+    const Value& eval(ExpressionContext&) override {
+        LOG(FATAL) << "LabelAttributeExpression has to be rewritten";
+    }
+
+    const std::string *leftLabel() const {
+        return static_cast<const LabelExpression*>(left())->name();
+    }
+
+    const std::string *rightLabel() const {
+        return static_cast<const LabelExpression*>(right())->name();
+    }
+
+    std::string toString() const override;
+};
+
+}   // namespace nebula
+
+#endif  // COMMON_EXPRESSION_LABELATTRIBUTEEXPRESSION_H_

--- a/src/common/expression/LabelAttributeExpression.h
+++ b/src/common/expression/LabelAttributeExpression.h
@@ -7,31 +7,54 @@
 #ifndef COMMON_EXPRESSION_LABELATTRIBUTEEXPRESSION_H_
 #define COMMON_EXPRESSION_LABELATTRIBUTEEXPRESSION_H_
 
-#include "common/expression/BinaryExpression.h"
 #include "common/expression/LabelExpression.h"
 
 namespace nebula {
 
 // label.label
-class LabelAttributeExpression final : public BinaryExpression {
+class LabelAttributeExpression final : public Expression {
 public:
-    explicit LabelAttributeExpression(Expression *lhs = nullptr,
-                                      Expression *rhs = nullptr)
-        : BinaryExpression(Kind::kLabelAttribute, lhs, rhs) {}
+    explicit LabelAttributeExpression(LabelExpression *lhs = nullptr,
+                                      LabelExpression *rhs = nullptr)
+        : Expression(Kind::kLabelAttribute) {
+        lhs_.reset(lhs);
+        rhs_.reset(rhs);
+    }
+
+    bool operator==(const Expression &rhs) const override {
+        if (rhs.kind() != kind()) {
+            return false;
+        }
+        auto &expr = static_cast<const LabelAttributeExpression&>(rhs);
+        return *lhs_ == *expr.lhs_ && *rhs_ == *expr.rhs_;
+    }
 
     const Value& eval(ExpressionContext&) override {
         LOG(FATAL) << "LabelAttributeExpression has to be rewritten";
     }
 
-    const std::string *leftLabel() const {
-        return static_cast<const LabelExpression*>(left())->name();
+    const LabelExpression* left() const {
+        return lhs_.get();
     }
 
-    const std::string *rightLabel() const {
-        return static_cast<const LabelExpression*>(right())->name();
+    const LabelExpression* right() const {
+        return rhs_.get();
     }
 
     std::string toString() const override;
+
+private:
+    void writeTo(Encoder&) const override {
+        LOG(FATAL) << "LabelAttributeExpression cannot be encoded";
+    }
+
+    void resetFrom(Decoder&) override {
+        LOG(FATAL) << "LabelAttributeExpression cannot be decoded";
+    }
+
+private:
+    std::unique_ptr<LabelExpression>    lhs_;
+    std::unique_ptr<LabelExpression>    rhs_;
 };
 
 }   // namespace nebula

--- a/src/common/expression/LabelExpression.cpp
+++ b/src/common/expression/LabelExpression.cpp
@@ -7,8 +7,10 @@
 #include "common/expression/LabelExpression.h"
 
 namespace nebula {
+
 const Value& LabelExpression::eval(ExpressionContext&) {
-    LOG(FATAL) << "Couldn't use directly";
+    result_.setStr(*name_);
+    return result_;
 }
 
 std::string LabelExpression::toString() const {

--- a/src/common/expression/LabelExpression.h
+++ b/src/common/expression/LabelExpression.h
@@ -12,6 +12,7 @@
 // The LabelExpression use for name_label in base_expression,
 // need to rewrite it based on the usage scenario
 namespace nebula {
+
 class LabelExpression: public Expression {
 public:
     explicit LabelExpression(std::string* name = nullptr)
@@ -39,6 +40,8 @@ protected:
     void resetFrom(Decoder& decoder) override;
 
     std::unique_ptr<std::string>    name_;
+    Value                           result_;
 };
+
 }  // namespace nebula
 #endif   // COMMON_EXPRESSION_LABELEXPRESSION_H_

--- a/src/common/expression/PropertyExpression.cpp
+++ b/src/common/expression/PropertyExpression.cpp
@@ -4,22 +4,22 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
-#include "common/expression/SymbolPropertyExpression.h"
+#include "common/expression/PropertyExpression.h"
 
 namespace nebula {
 
 
-bool SymbolPropertyExpression::operator==(const Expression& rhs) const {
+bool PropertyExpression::operator==(const Expression& rhs) const {
     if (kind_ != rhs.kind()) {
         return false;
     }
 
-    const auto& r = dynamic_cast<const SymbolPropertyExpression&>(rhs);
+    const auto& r = dynamic_cast<const PropertyExpression&>(rhs);
     return *ref_ == *(r.ref_) && *sym_ == *(r.sym_) && *prop_ == *(r.prop_);
 }
 
 
-void SymbolPropertyExpression::writeTo(Encoder& encoder) const {
+void PropertyExpression::writeTo(Encoder& encoder) const {
     // kind_
     encoder << kind_;
 
@@ -34,7 +34,7 @@ void SymbolPropertyExpression::writeTo(Encoder& encoder) const {
 }
 
 
-void SymbolPropertyExpression::resetFrom(Decoder& decoder) {
+void PropertyExpression::resetFrom(Decoder& decoder) {
     // Read ref_
     ref_ = decoder.readStr();
 
@@ -45,7 +45,7 @@ void SymbolPropertyExpression::resetFrom(Decoder& decoder) {
     prop_ = decoder.readStr();
 }
 
-const Value& SymbolPropertyExpression::eval(ExpressionContext& ctx) {
+const Value& PropertyExpression::eval(ExpressionContext& ctx) {
     // TODO maybe cypher need it.
     UNUSED(ctx);
     LOG(FATAL) << "Unimplemented";
@@ -106,7 +106,7 @@ const Value& EdgeDstIdExpression::eval(ExpressionContext& ctx) {
     return result_;
 }
 
-std::string SymbolPropertyExpression::toString() const {
+std::string PropertyExpression::toString() const {
     std::string buf;
     buf.reserve(64);
 

--- a/src/common/expression/PropertyExpression.h
+++ b/src/common/expression/PropertyExpression.h
@@ -4,8 +4,8 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
-#ifndef COMMON_EXPRESSION_SYMBOLPROPERTYEXPRESSION_H_
-#define COMMON_EXPRESSION_SYMBOLPROPERTYEXPRESSION_H_
+#ifndef COMMON_EXPRESSION_PROPERTYEXPRESSION_H_
+#define COMMON_EXPRESSION_PROPERTYEXPRESSION_H_
 
 #include "common/expression/Expression.h"
 
@@ -22,23 +22,12 @@ constexpr char const kDstRef[] = "$$";
 // 2. symbol, a symbol name, e.g. tag_name, edge_name, variable_name,
 // 3. property, property name.
 //
-// The SymbolPropertyExpression will only be used in parser to indicate
+// The PropertyExpression will only be used in parser to indicate
 // the form of symbol.prop, it will be transform to a proper expression
 // in a parse rule.
-class SymbolPropertyExpression: public Expression {
+class PropertyExpression: public Expression {
     friend class Expression;
 public:
-    SymbolPropertyExpression() : Expression(Kind::kSymProperty) {}
-    SymbolPropertyExpression(Kind kind,
-                             std::string* ref,
-                             std::string* sym,
-                             std::string* prop)
-        : Expression(kind) {
-        ref_.reset(ref);
-        sym_.reset(sym);
-        prop_.reset(prop);
-    }
-
     bool operator==(const Expression& rhs) const override;
 
     const Value& eval(ExpressionContext& ctx) override;
@@ -58,6 +47,16 @@ public:
     std::string toString() const override;
 
 protected:
+    PropertyExpression(Kind kind,
+                       std::string* ref,
+                       std::string* sym,
+                       std::string* prop)
+        : Expression(kind) {
+        ref_.reset(ref);
+        sym_.reset(sym);
+        prop_.reset(prop);
+    }
+
     void writeTo(Encoder& encoder) const override;
 
     void resetFrom(Decoder& decoder) override;
@@ -68,11 +67,11 @@ protected:
 };
 
 // edge_name.any_prop_name
-class EdgePropertyExpression final : public SymbolPropertyExpression {
+class EdgePropertyExpression final : public PropertyExpression {
 public:
     EdgePropertyExpression(std::string* edge = nullptr,
                            std::string* prop = nullptr)
-        : SymbolPropertyExpression(Kind::kEdgeProperty,
+        : PropertyExpression(Kind::kEdgeProperty,
                                    new std::string(""),
                                    edge,
                                    prop) {}
@@ -87,14 +86,14 @@ private:
 
 
 // tag_name.any_prop_name
-class TagPropertyExpression final : public SymbolPropertyExpression {
+class TagPropertyExpression final : public PropertyExpression {
 public:
     TagPropertyExpression(std::string* tag = nullptr,
                           std::string* prop = nullptr)
-        : SymbolPropertyExpression(Kind::kTagProperty,
-                                   new std::string(""),
-                                   tag,
-                                   prop) {}
+        : PropertyExpression(Kind::kTagProperty,
+                             new std::string(""),
+                             tag,
+                             prop) {}
 
     const Value& eval(ExpressionContext& ctx) override;
 
@@ -104,13 +103,13 @@ private:
 };
 
 // $-.any_prop_name
-class InputPropertyExpression final : public SymbolPropertyExpression {
+class InputPropertyExpression final : public PropertyExpression {
 public:
     explicit InputPropertyExpression(std::string* prop = nullptr)
-        : SymbolPropertyExpression(Kind::kInputProperty,
-                                   new std::string(kInputRef),
-                                   new std::string(""),
-                                   prop) {}
+        : PropertyExpression(Kind::kInputProperty,
+                             new std::string(kInputRef),
+                             new std::string(""),
+                             prop) {}
 
     const Value& eval(ExpressionContext& ctx) override;
 
@@ -118,14 +117,14 @@ public:
 };
 
 // $VarName.any_prop_name
-class VariablePropertyExpression final : public SymbolPropertyExpression {
+class VariablePropertyExpression final : public PropertyExpression {
 public:
     VariablePropertyExpression(std::string* var = nullptr,
                                std::string* prop = nullptr)
-        : SymbolPropertyExpression(Kind::kVarProperty,
-                                   new std::string(kVarRef),
-                                   var,
-                                   prop) {}
+        : PropertyExpression(Kind::kVarProperty,
+                             new std::string(kVarRef),
+                             var,
+                             prop) {}
 
     const Value& eval(ExpressionContext& ctx) override;
 
@@ -133,14 +132,14 @@ public:
 };
 
 // $^.TagName.any_prop_name
-class SourcePropertyExpression final : public SymbolPropertyExpression {
+class SourcePropertyExpression final : public PropertyExpression {
 public:
     SourcePropertyExpression(std::string* tag = nullptr,
                              std::string* prop = nullptr)
-        : SymbolPropertyExpression(Kind::kSrcProperty,
-                                   new std::string(kSrcRef),
-                                   tag,
-                                   prop) {}
+        : PropertyExpression(Kind::kSrcProperty,
+                             new std::string(kSrcRef),
+                             tag,
+                             prop) {}
 
     const Value& eval(ExpressionContext& ctx) override;
 
@@ -151,14 +150,14 @@ private:
 };
 
 // $$.TagName.any_prop_name
-class DestPropertyExpression final : public SymbolPropertyExpression {
+class DestPropertyExpression final : public PropertyExpression {
 public:
     DestPropertyExpression(std::string* tag = nullptr,
                            std::string* prop = nullptr)
-        : SymbolPropertyExpression(Kind::kDstProperty,
-                                   new std::string(kDstRef),
-                                   tag,
-                                   prop) {}
+        : PropertyExpression(Kind::kDstProperty,
+                             new std::string(kDstRef),
+                             tag,
+                             prop) {}
 
     const Value& eval(ExpressionContext& ctx) override;
 
@@ -166,13 +165,13 @@ public:
 };
 
 // EdgeName._src
-class EdgeSrcIdExpression final : public SymbolPropertyExpression {
+class EdgeSrcIdExpression final : public PropertyExpression {
 public:
     explicit EdgeSrcIdExpression(std::string* edge = nullptr)
-        : SymbolPropertyExpression(Kind::kEdgeSrc,
-                                   new std::string(""),
-                                   edge,
-                                   new std::string(kSrc)) {}
+        : PropertyExpression(Kind::kEdgeSrc,
+                             new std::string(""),
+                             edge,
+                             new std::string(kSrc)) {}
 
     const Value& eval(ExpressionContext& ctx) override;
 
@@ -183,13 +182,13 @@ private:
 };
 
 // EdgeName._type
-class EdgeTypeExpression final : public SymbolPropertyExpression {
+class EdgeTypeExpression final : public PropertyExpression {
 public:
     explicit EdgeTypeExpression(std::string* edge = nullptr)
-        : SymbolPropertyExpression(Kind::kEdgeType,
-                                   new std::string(""),
-                                   edge,
-                                   new std::string(kType)) {}
+        : PropertyExpression(Kind::kEdgeType,
+                             new std::string(""),
+                             edge,
+                             new std::string(kType)) {}
 
     const Value& eval(ExpressionContext& ctx) override;
 
@@ -200,13 +199,13 @@ private:
 };
 
 // EdgeName._rank
-class EdgeRankExpression final : public SymbolPropertyExpression {
+class EdgeRankExpression final : public PropertyExpression {
 public:
     explicit EdgeRankExpression(std::string* edge = nullptr)
-        : SymbolPropertyExpression(Kind::kEdgeRank,
-                                   new std::string(""),
-                                   edge,
-                                   new std::string(kRank)) {}
+        : PropertyExpression(Kind::kEdgeRank,
+                             new std::string(""),
+                             edge,
+                             new std::string(kRank)) {}
 
     const Value& eval(ExpressionContext& ctx) override;
 
@@ -217,13 +216,13 @@ private:
 };
 
 // EdgeName._dst
-class EdgeDstIdExpression final : public SymbolPropertyExpression {
+class EdgeDstIdExpression final : public PropertyExpression {
 public:
     explicit EdgeDstIdExpression(std::string* edge = nullptr)
-        : SymbolPropertyExpression(Kind::kEdgeDst,
-                                   new std::string(""),
-                                   edge,
-                                   new std::string(kDst)) {}
+        : PropertyExpression(Kind::kEdgeDst,
+                             new std::string(""),
+                             edge,
+                             new std::string(kDst)) {}
 
     const Value& eval(ExpressionContext& ctx) override;
 

--- a/src/common/expression/PropertyExpression.h
+++ b/src/common/expression/PropertyExpression.h
@@ -72,9 +72,9 @@ public:
     EdgePropertyExpression(std::string* edge = nullptr,
                            std::string* prop = nullptr)
         : PropertyExpression(Kind::kEdgeProperty,
-                                   new std::string(""),
-                                   edge,
-                                   prop) {}
+                             new std::string(""),
+                             edge,
+                             prop) {}
 
     const Value& eval(ExpressionContext& ctx) override;
 

--- a/src/common/expression/VertexExpression.cpp
+++ b/src/common/expression/VertexExpression.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019 vesoft inc. All rights reserved.
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.

--- a/src/common/expression/VertexExpression.cpp
+++ b/src/common/expression/VertexExpression.cpp
@@ -1,0 +1,16 @@
+/* Copyright (c) 2019 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "common/expression/VertexExpression.h"
+
+namespace nebula {
+
+const Value& VertexExpression::eval(ExpressionContext &ctx) {
+    result_ = ctx.getVertex();
+    return result_;
+}
+
+}   // namespace nebula

--- a/src/common/expression/VertexExpression.h
+++ b/src/common/expression/VertexExpression.h
@@ -1,0 +1,47 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef COMMON_EXPRESSION_VERTEXEXPRESSION_H_
+#define COMMON_EXPRESSION_VERTEXEXPRESSION_H_
+
+#include "common/expression/Expression.h"
+
+namespace nebula {
+
+/**
+ * This is an internal type of expression to denote a Vertex value.
+ * It has no corresponding rules in parser.
+ * It is generated from LabelExpression during semantic analysis
+ * and expression rewrite.
+ */
+class VertexExpression final : public Expression {
+public:
+    VertexExpression() : Expression(Kind::kVertex) {}
+
+    const Value& eval(ExpressionContext &ctx) override;
+
+    std::string toString() const override {
+        return "VERTEX";
+    }
+
+    bool operator==(const Expression &expr) const override {
+        return kind() == expr.kind();
+    }
+
+private:
+    void writeTo(Encoder &encoder) const override {
+        encoder << kind();
+    }
+
+    void resetFrom(Decoder&) override {}
+
+private:
+    Value                                   result_;
+};
+
+}   // namespace nebula
+
+#endif  // COMMON_EXPRESSION_VERTEXEXPRESSION_H_

--- a/src/common/expression/test/EncodeDecodeTest.cpp
+++ b/src/common/expression/test/EncodeDecodeTest.cpp
@@ -6,7 +6,7 @@
 
 #include "common/base/Base.h"
 #include <gtest/gtest.h>
-#include "common/expression/SymbolPropertyExpression.h"
+#include "common/expression/PropertyExpression.h"
 #include "common/expression/ArithmeticExpression.h"
 #include "common/expression/ConstantExpression.h"
 #include "common/expression/FunctionCallExpression.h"
@@ -46,17 +46,9 @@ TEST(ExpressionEncodeDecode, ConstantExpression) {
 
 
 TEST(ExpressionEncodeDecode, SymbolPropertyExpression) {
-    SymbolPropertyExpression symbolExpr(Expression::Kind::kSymProperty,
-                                        new std::string(""),
-                                        new std::string("symbol"),
-                                        new std::string("prop"));
-    std::string encoded = Expression::encode(symbolExpr);
-    auto decoded = Expression::decode(encoded);
-    EXPECT_EQ(symbolExpr, *decoded);
-
     InputPropertyExpression inputEx(new std::string("prop"));
-    encoded = Expression::encode(inputEx);
-    decoded = Expression::decode(folly::StringPiece(encoded.data(), encoded.size()));
+    auto encoded = Expression::encode(inputEx);
+    auto decoded = Expression::decode(folly::StringPiece(encoded.data(), encoded.size()));
     EXPECT_EQ(inputEx, *decoded);
 
     VariablePropertyExpression varEx(new std::string("var"), new std::string("prop"));

--- a/src/common/expression/test/ExpressionBenchmark.cpp
+++ b/src/common/expression/test/ExpressionBenchmark.cpp
@@ -8,7 +8,7 @@
 #include "common/expression/test/ExpressionContextMock.h"
 #include "common/expression/ArithmeticExpression.h"
 #include "common/expression/ConstantExpression.h"
-#include "common/expression/SymbolPropertyExpression.h"
+#include "common/expression/PropertyExpression.h"
 #include "common/expression/RelationalExpression.h"
 
 nebula::ExpressionContextMock gExpCtxt;

--- a/src/common/expression/test/ExpressionContextMock.h
+++ b/src/common/expression/test/ExpressionContextMock.h
@@ -109,6 +109,14 @@ public:
         }
     }
 
+    Value getVertex() const override {
+        return Value();
+    }
+
+    Value getEdge() const override {
+        return Value();
+    }
+
     void setVar(const std::string& var, Value val) override {
         UNUSED(var);
         UNUSED(val);


### PR DESCRIPTION
 * Add `AttributeExpression` to denote the form `<expr>.label`
 * Add `EdgeExpression` and `VertexExpression` to represent the Vertex and Edge object internally.
 * Rename `SymbolPropertyExpression` to `PropertyExpression`, AKA. the base class of all property-related expressions.
 * Add `LabelAttributeExpression` to denote an unresolved expression of the form `label.label`. Thus all `PropertyExpression` are deterministic now.