### PR TITLE
Add encode/decode to LabelAttributeExpression

### DIFF
--- a/src/common/expression/LabelAttributeExpression.h
+++ b/src/common/expression/LabelAttributeExpression.h
@@ -44,12 +44,19 @@ public:
     std::string toString() const override;
 
 private:
-    void writeTo(Encoder&) const override {
-        LOG(FATAL) << "LabelAttributeExpression cannot be encoded";
+    void writeTo(Encoder &encoder) const override {
+        encoder << kind_;
+        encoder << *lhs_;
+        encoder << *rhs_;
     }
 
-    void resetFrom(Decoder&) override {
-        LOG(FATAL) << "LabelAttributeExpression cannot be decoded";
+    void resetFrom(Decoder &decoder) override {
+        auto *lhs = decoder.readExpression().release();
+        auto *rhs = decoder.readExpression().release();
+        DCHECK(lhs->kind() == Kind::kLabel);
+        DCHECK(rhs->kind() == Kind::kLabel);
+        lhs_.reset(static_cast<LabelExpression*>(lhs));
+        rhs_.reset(static_cast<LabelExpression*>(rhs));
     }
 
 private:

--- a/src/common/expression/LabelExpression.h
+++ b/src/common/expression/LabelExpression.h
@@ -24,6 +24,10 @@ public:
         }
     }
 
+    explicit LabelExpression(std::string name)
+        : LabelExpression(new std::string(std::move(name))) {
+    }
+
     bool operator==(const Expression& rhs) const override;
 
     const Value& eval(ExpressionContext& ctx) override;

--- a/src/common/expression/LogicalExpression.cpp
+++ b/src/common/expression/LogicalExpression.cpp
@@ -37,7 +37,7 @@ std::string LogicalExpression::toString() const {
             op = "||";
             break;
         case Kind::kLogicalXor:
-            op = "^";
+            op = "XOR";
             break;
         default:
             op = "illegal symbol ";


### PR DESCRIPTION
Because now we are using encode and decode to implement expression clone, we have to override relative methods.