### PR TITLE
Add clone interface for expression

### DIFF
--- a/src/common/expression/Expression.cpp
+++ b/src/common/expression/Expression.cpp
@@ -169,6 +169,10 @@ std::unique_ptr<Expression> Expression::Decoder::readExpression() noexcept {
  *  class Expression
  *
  ***************************************/
+std::unique_ptr<Expression> Expression::clone() const {
+    return decode(encode());
+}
+
 // static
 std::string Expression::encode(const Expression& exp) {
     return exp.encode();

--- a/src/common/expression/Expression.h
+++ b/src/common/expression/Expression.h
@@ -101,9 +101,12 @@ public:
 
     virtual void accept(ExprVisitor* visitor) = 0;
 
-    static std::string encode(const Expression& exp);
+    // Deep copy
+    std::unique_ptr<Expression> clone() const;
 
     std::string encode() const;
+
+    static std::string encode(const Expression& exp);
 
     static std::unique_ptr<Expression> decode(folly::StringPiece encoded);
 

--- a/src/common/expression/test/ExpressionTest.cpp
+++ b/src/common/expression/test/ExpressionTest.cpp
@@ -1883,6 +1883,21 @@ TEST_F(ExpressionTest, LabelEvaluate) {
     ASSERT_EQ("name", value.getStr());
 }
 
+TEST_F(ExpressionTest, TestExprClone) {
+    ConstantExpression expr(1);
+    auto clone = expr.clone();
+    ASSERT_NE(clone.get(), &expr);
+    ASSERT_EQ(clone->kind(), expr.kind());
+    ASSERT_EQ(static_cast<ConstantExpression *>(clone.get())->toString(), expr.toString());
+
+    ArithmeticExpression aexpr(
+        Expression::Kind::kAdd, new ConstantExpression(1), new ConstantExpression(1));
+    auto aclone = aexpr.clone();
+    ASSERT_NE(aclone.get(), &aexpr);
+    ASSERT_EQ(aclone->kind(), aexpr.kind());
+    ASSERT_EQ(static_cast<ArithmeticExpression *>(aclone.get())->toString(), aexpr.toString());
+}
+
 }  // namespace nebula
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This clone is a deep copy of original expression object.

To simplify the following use case:

```cpp
Expression *expr = ...;
auto cloneExpr = Expression::decode(Expression::encode(*expr));
// =>
auto cloneExpr = expr->clone();
```