### PR TITLE
Support getSchemaIDByName in SchemaManager

### DIFF
--- a/src/common/meta/SchemaManager.cpp
+++ b/src/common/meta/SchemaManager.cpp
@@ -16,5 +16,19 @@ std::unique_ptr<SchemaManager> SchemaManager::create(MetaClient *client) {
     return mgr;
 }
 
+StatusOr<std::pair<bool, int32_t>>
+SchemaManager::getSchemaIDByName(GraphSpaceID space, folly::StringPiece schemaName) {
+    auto ret = toEdgeType(space, schemaName);
+    if (ret.ok()) {
+        return std::make_pair(true, ret.value());
+    } else {
+        ret = toTagID(space, schemaName);
+        if (ret.ok()) {
+            return std::make_pair(false, ret.value());
+        }
+    }
+    return Status::Error("Schema not exist: %s", schemaName.str().c_str());
+}
+
 }   // namespace meta
 }   // namespace nebula

--- a/src/common/meta/SchemaManager.h
+++ b/src/common/meta/SchemaManager.h
@@ -61,6 +61,9 @@ public:
     // get all version of all edge schema
     virtual StatusOr<EdgeSchemas> getAllVerEdgeSchema(GraphSpaceID space) = 0;
 
+    // Get the TagID or EdgeType by the name.
+    // The first one is a bool which is used to distinguish the type.
+    // When the result is an edge, it's true, otherwise it's false.
     StatusOr<std::pair<bool, int32_t>>
     getSchemaIDByName(GraphSpaceID space, folly::StringPiece schemaName);
 

--- a/src/common/meta/SchemaManager.h
+++ b/src/common/meta/SchemaManager.h
@@ -61,6 +61,8 @@ public:
     // get all version of all edge schema
     virtual StatusOr<EdgeSchemas> getAllVerEdgeSchema(GraphSpaceID space) = 0;
 
+    StatusOr<std::pair<bool, int32_t>>
+    getSchemaIDByName(GraphSpaceID space, folly::StringPiece schemaName);
 
 protected:
     SchemaManager() = default;


### PR DESCRIPTION
This interface will be used by `Graph Layer` and `Storage Layer` later. 

It's to avoid some duplicate check when operate the indexes.