### PR TITLE
added StartsWith() and EndsWith() in RelationalExpression.cpp

### DIFF
--- a/src/common/expression/Expression.cpp
+++ b/src/common/expression/Expression.cpp
@@ -296,6 +296,16 @@ std::unique_ptr<Expression> Expression::decode(Expression::Decoder& decoder) {
             exp->resetFrom(decoder);
             return exp;
         }
+        case Expression::Kind::kStartsWith: {
+            exp = std::make_unique<RelationalExpression>(Expression::Kind::kStartsWith);
+            exp->resetFrom(decoder);
+            return exp;
+        }
+        case Expression::Kind::kEndsWith: {
+            exp = std::make_unique<RelationalExpression>(Expression::Kind::kEndsWith);
+            exp->resetFrom(decoder);
+            return exp;
+        }
         case Expression::Kind::kSubscript: {
             exp = std::make_unique<SubscriptExpression>();
             exp->resetFrom(decoder);
@@ -495,6 +505,12 @@ std::ostream& operator<<(std::ostream& os, Expression::Kind kind) {
             break;
         case Expression::Kind::kContains:
             os << "Contains";
+            break;
+        case Expression::Kind::kStartsWith:
+            os << "kStartsWith";
+            break;
+        case Expression::Kind::kEndsWith:
+            os << "kEndsWith";
             break;
         case Expression::Kind::kSubscript:
             os << "Subscript";

--- a/src/common/expression/Expression.cpp
+++ b/src/common/expression/Expression.cpp
@@ -507,10 +507,10 @@ std::ostream& operator<<(std::ostream& os, Expression::Kind kind) {
             os << "Contains";
             break;
         case Expression::Kind::kStartsWith:
-            os << "kStartsWith";
+            os << "StartsWith";
             break;
         case Expression::Kind::kEndsWith:
-            os << "kEndsWith";
+            os << "EndsWith";
             break;
         case Expression::Kind::kSubscript:
             os << "Subscript";

--- a/src/common/expression/Expression.h
+++ b/src/common/expression/Expression.h
@@ -41,6 +41,8 @@ public:
         kRelIn,
         kRelNotIn,
         kContains,
+        kStartsWith,
+        kEndsWith,
         kSubscript,
         kAttribute,
         kLabelAttribute,

--- a/src/common/expression/RelationalExpression.cpp
+++ b/src/common/expression/RelationalExpression.cpp
@@ -67,7 +67,26 @@ const Value& RelationalExpression::eval(ExpressionContext& ctx) {
         }
         case Kind::kContains: {
             if (lhs.isStr() && rhs.isStr()) {
-                result_ = lhs.getStr().find(rhs.getStr()) != std::string::npos;
+                result_ = lhs.getStr().size() >= rhs.getStr().size() &&
+                    lhs.getStr().find(rhs.getStr()) != std::string::npos;
+            } else {
+                return Value::kNullBadType;
+            }
+            break;
+        }
+        case Kind::kStartsWith: {
+            if (lhs.isStr() && rhs.isStr()) {
+                result_ = lhs.getStr().size() >= rhs.getStr().size() &&
+                    lhs.getStr().find(rhs.getStr()) == 0;
+            } else {
+                return Value::kNullBadType;
+            }
+            break;
+        }
+        case Kind::kEndsWith: {
+            if (lhs.isStr() && rhs.isStr()) {
+                std::size_t lhsLen = lhs.getStr().size(), rhsLen = rhs.getStr().size();
+                result_ = lhsLen >= rhsLen && lhs.getStr().rfind(rhs.getStr()) == lhsLen - rhsLen;
             } else {
                 return Value::kNullBadType;
             }

--- a/src/common/expression/RelationalExpression.cpp
+++ b/src/common/expression/RelationalExpression.cpp
@@ -128,8 +128,14 @@ std::string RelationalExpression::toString() const {
         case Kind::kContains:
             op = " CONTAINS ";
             break;
+        case Kind::kStartsWith:
+            op = " STARTS WITH ";
+            break;
+        case Kind::kEndsWith:
+            op = " ENDS WITH ";
+            break;
         default:
-            op = "illegal symbol ";
+            op = " illegal symbol ";
     }
     std::stringstream out;
     out << "(" << lhs_->toString() << op << rhs_->toString() << ")";

--- a/src/common/expression/test/ExpressionTest.cpp
+++ b/src/common/expression/test/ExpressionTest.cpp
@@ -1873,6 +1873,202 @@ TEST_F(ExpressionTest, RelationContains) {
     }
 }
 
+TEST_F(ExpressionTest, RelationStartsWith) {
+    {
+        // "abc" starts with "a"
+        RelationalExpression expr(
+                Expression::Kind::kStartsWith,
+                new ConstantExpression("abc"),
+                new ConstantExpression("a"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, true);
+    }
+    {
+        // "abc" starts with "ab"
+        RelationalExpression expr(
+                Expression::Kind::kStartsWith,
+                new ConstantExpression("abc"),
+                new ConstantExpression("ab"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, true);
+    }
+    {
+        // "1234"" starts with "12"
+        RelationalExpression expr(
+                Expression::Kind::kStartsWith,
+                new ConstantExpression("1234"),
+                new ConstantExpression("12"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, true);
+    }
+    {
+        // "1234"" starts with "34"
+        RelationalExpression expr(
+                Expression::Kind::kStartsWith,
+                new ConstantExpression("1234"),
+                new ConstantExpression("34"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, false);
+    }
+    {
+        // "abc" starts with "bc"
+        RelationalExpression expr(
+                Expression::Kind::kStartsWith,
+                new ConstantExpression("abc"),
+                new ConstantExpression("bc"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, false);
+    }
+    {
+        // "abc" starts with "ac"
+        RelationalExpression expr(
+                Expression::Kind::kStartsWith,
+                new ConstantExpression("abc"),
+                new ConstantExpression("ac"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, false);
+    }
+    {
+        // "abc" starts with "AB"
+        RelationalExpression expr(
+                Expression::Kind::kStartsWith,
+                new ConstantExpression("abc"),
+                new ConstantExpression("AB"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, false);
+    }
+    {
+        // "abc" starts with 1
+        RelationalExpression expr(
+                Expression::Kind::kStartsWith,
+                new ConstantExpression("abc1"),
+                new ConstantExpression(1));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::NULLVALUE);
+        EXPECT_EQ(eval, Value::kNullBadType);
+    }
+    {
+        // 1234 starts with 1
+        RelationalExpression expr(
+                Expression::Kind::kStartsWith,
+                new ConstantExpression(1234),
+                new ConstantExpression(1));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::NULLVALUE);
+        EXPECT_EQ(eval, Value::kNullBadType);
+    }
+}
+
+TEST_F(ExpressionTest, RelationEndsWith) {
+    {
+        // "abc" ends with "a"
+        RelationalExpression expr(
+                Expression::Kind::kEndsWith,
+                new ConstantExpression("abc"),
+                new ConstantExpression("a"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, false);
+    }
+    {
+        // "abc" starts with "ab"
+        RelationalExpression expr(
+                Expression::Kind::kEndsWith,
+                new ConstantExpression("abc"),
+                new ConstantExpression("ab"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, false);
+    }
+    {
+        // "1234"" ends with "12"
+        RelationalExpression expr(
+                Expression::Kind::kEndsWith,
+                new ConstantExpression("1234"),
+                new ConstantExpression("12"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, false);
+    }
+    {
+        // "1234"" ends with "34"
+        RelationalExpression expr(
+                Expression::Kind::kEndsWith,
+                new ConstantExpression("1234"),
+                new ConstantExpression("34"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, true);
+    }
+    {
+        // "abc" ends with "bc"
+        RelationalExpression expr(
+                Expression::Kind::kEndsWith,
+                new ConstantExpression("abc"),
+                new ConstantExpression("bc"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, true);
+    }
+    {
+        // "abc" ends with "ac"
+        RelationalExpression expr(
+                Expression::Kind::kEndsWith,
+                new ConstantExpression("abc"),
+                new ConstantExpression("ac"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, false);
+    }
+    {
+        // "abc" ends with "AB"
+        RelationalExpression expr(
+                Expression::Kind::kEndsWith,
+                new ConstantExpression("abc"),
+                new ConstantExpression("AB"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, false);
+    }
+    {
+        // "abc" ends with "BC"
+        RelationalExpression expr(
+                Expression::Kind::kEndsWith,
+                new ConstantExpression("abc"),
+                new ConstantExpression("BC"));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::BOOL);
+        EXPECT_EQ(eval, false);
+    }
+    {
+        // "abc" starts with 1
+        RelationalExpression expr(
+                Expression::Kind::kEndsWith,
+                new ConstantExpression("abc1"),
+                new ConstantExpression(1));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::NULLVALUE);
+        EXPECT_EQ(eval, Value::kNullBadType);
+    }
+    {
+        // 1234 starts with 1
+        RelationalExpression expr(
+                Expression::Kind::kEndsWith,
+                new ConstantExpression(1234),
+                new ConstantExpression(1));
+        auto eval = Expression::eval(&expr, gExpCtxt);
+        EXPECT_EQ(eval.type(), Value::Type::NULLVALUE);
+        EXPECT_EQ(eval, Value::kNullBadType);
+    }
+}
+
 TEST_F(ExpressionTest, ContainsToString) {
     {
         // "abc" contains "a"


### PR DESCRIPTION
regarding issue: fixes #252 
1. added StartsWith() and EndsWith() in RelationalExpression.cpp
2. updated test cases for new functions