### PR TITLE
add getSpaceVidType

### DIFF
--- a/src/common/meta/SchemaManager.h
+++ b/src/common/meta/SchemaManager.h
@@ -31,6 +31,10 @@ public:
 
     virtual StatusOr<int32_t> getSpaceVidLen(GraphSpaceID space) = 0;
 
+    virtual StatusOr<cpp2::PropertyType> getSpaceVidType(GraphSpaceID) {
+        return Status::Error("Not implemented");
+    }
+
     virtual std::shared_ptr<const NebulaSchemaProvider>
     getTagSchema(GraphSpaceID space, TagID tag, SchemaVer ver = -1) = 0;
 

--- a/src/common/meta/ServerBasedSchemaManager.cpp
+++ b/src/common/meta/ServerBasedSchemaManager.cpp
@@ -26,6 +26,11 @@ StatusOr<int32_t> ServerBasedSchemaManager::getSpaceVidLen(GraphSpaceID space) {
     return metaClient_->getSpaceVidLen(space);
 }
 
+StatusOr<cpp2::PropertyType> ServerBasedSchemaManager::getSpaceVidType(GraphSpaceID space) {
+    CHECK(metaClient_);
+    return metaClient_->getSpaceVidType(space);
+}
+
 std::shared_ptr<const NebulaSchemaProvider>
 ServerBasedSchemaManager::getTagSchema(GraphSpaceID space, TagID tag, SchemaVer ver) {
     VLOG(3) << "Get Tag Schema Space " << space << ", TagID " << tag << ", Version " << ver;

--- a/src/common/meta/ServerBasedSchemaManager.h
+++ b/src/common/meta/ServerBasedSchemaManager.h
@@ -22,6 +22,8 @@ public:
 
     StatusOr<int32_t> getSpaceVidLen(GraphSpaceID space) override;
 
+    StatusOr<cpp2::PropertyType> getSpaceVidType(GraphSpaceID space) override;
+
     // return the newest one if ver less 0
     std::shared_ptr<const NebulaSchemaProvider>
     getTagSchema(GraphSpaceID space, TagID tag, SchemaVer ver = -1) override;


### PR DESCRIPTION
To fix https://github.com/vesoft-inc/nebula-storage/issues/170 and https://github.com/vesoft-inc/nebula-storage/issues/166, storage need to be aware of vid type. And can trim trailing \0 if the space vid is string with fixed length.

Needed by https://github.com/vesoft-inc/nebula-storage/pull/172.