### PR TITLE
Add .debug_gdb_scripts section to improve debugging experience

### DIFF
--- a/cmake/nebula/ConfigNebulaCommon.cmake
+++ b/cmake/nebula/ConfigNebulaCommon.cmake
@@ -36,6 +36,7 @@ macro(config_nebula_common)
                 -DENABLE_PIC=${ENABLE_PIC}
                 -DENABLE_COMPRESSED_DEBUG_INFO=${ENABLE_COMPRESSED_DEBUG_INFO}
                 -DNEBULA_USE_LINKER=${NEBULA_USE_LINKER}
+                -DENABLE_GDB_SCRIPT_SECTION=${ENABLE_GDB_SCRIPT_SECTION}
                 ${common_source_dir}
         WORKING_DIRECTORY ${common_build_dir}
         RESULT_VARIABLE cmake_status

--- a/cmake/nebula/GeneralCMakeOptions.cmake
+++ b/cmake/nebula/GeneralCMakeOptions.cmake
@@ -16,6 +16,7 @@ option(ENABLE_COVERAGE                  "Build with coverage report" OFF)
 option(ENABLE_PIC                       "Build with -fPIC" OFF)
 option(ENABLE_COMPRESSED_DEBUG_INFO     "Compress debug info to reduce binary size" ON)
 option(ENABLE_CLANG_TIDY                "Enable clang-tidy if present" OFF)
+option(ENABLE_GDB_SCRIPT_SECTION        "Add .debug_gdb_scripts section" OFF)
 
 get_cmake_property(variable_list VARIABLES)
 foreach(_varname ${variable_list})

--- a/src/common/base/CMakeLists.txt
+++ b/src/common/base/CMakeLists.txt
@@ -3,6 +3,10 @@
 # This source code is licensed under Apache 2.0 License,
 # attached with Common Clause Condition 1.0, found in the LICENSES directory.
 
+if (ENABLE_GDB_SCRIPT_SECTION)
+    set(gdb_debug_script GdbDebugScript.cpp)
+endif()
+
 nebula_add_library(
     base_obj OBJECT
     Base.cpp
@@ -12,6 +16,7 @@ nebula_add_library(
     SignalHandler.cpp
     SlowOpTracker.cpp
     StringValue.cpp
+    ${gdb_debug_script}
 )
 
 nebula_add_subdirectory(test)

--- a/src/common/base/GdbDebugScript.cpp
+++ b/src/common/base/GdbDebugScript.cpp
@@ -1,0 +1,18 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+asm(
+".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
+".byte 4" "\n"
+".ascii \"gdb.inlined-script\\n\"\n"
+".ascii \"import glob\\n\"\n"
+".ascii \"path = glob.glob('/usr/share/gcc-*/python')\\n\"\n"
+".ascii \"sys.path = path + sys.path\\n\"\n"
+".ascii \"from libstdcxx.v6 import register_libstdcxx_printers \\n\"\n"
+".ascii \"register_libstdcxx_printers(gdb.current_objfile()) \\n\"\n"
+".byte 0\n"
+".popsection\n"
+);


### PR DESCRIPTION
Because we link against libstdc++ statically, GDB cannot automatically load pretty printers for STL data structures. This PR add an option to add a special ELF section to each executable to load those printers.