### PR TITLE
unify all storage interface behavior

### DIFF
--- a/src/common/base/Base.h
+++ b/src/common/base/Base.h
@@ -130,6 +130,7 @@ using VariantType = boost::variant<int64_t, double, bool, std::string>;
 // reserved property names
 constexpr char kId[]    = "_id";
 constexpr char kVid[]   = "_vid";
+constexpr char kTag[]   = "_tag";
 constexpr char kSrc[]   = "_src";
 constexpr char kType[]  = "_type";
 constexpr char kRank[]  = "_rank";

--- a/src/common/clients/storage/GraphStorageClient.cpp
+++ b/src/common/clients/storage/GraphStorageClient.cpp
@@ -193,7 +193,6 @@ GraphStorageClient::getProps(GraphSpaceID space,
         auto& host = c.first;
         auto& req = requests[host];
         req.set_space_id(space);
-        req.set_column_names(std::move(input.colNames));
         req.set_parts(std::move(c.second));
         req.set_dedup(dedup);
         if (vertexProps != nullptr) {

--- a/src/common/interface/storage.thrift
+++ b/src/common/interface/storage.thrift
@@ -465,7 +465,7 @@ struct UpdateVertexRequest {
     4: required common.TagID        tag_id
     5: list<UpdatedProp>            updated_props,
     6: optional bool                insertable = false,
-    // A list of expressions
+    // A list of kSrcProperty expressions, support kVid and kTag
     7: optional list<binary>        return_props,
     // If provided, the update happens only when the condition evaluates true
     8: optional binary              condition,
@@ -484,7 +484,7 @@ struct UpdateEdgeRequest {
     3: EdgeKey                  edge_key,
     4: list<UpdatedProp>        updated_props,
     5: optional bool            insertable = false,
-    // A list of expressions
+    // A list of kEdgeProperty expressions, support kSrc, kType, kRank and kDst
     6: optional list<binary>    return_props,
     // If provided, the update happens only when the condition evaluates true
     7: optional binary          condition,

--- a/src/common/interface/storage.thrift
+++ b/src/common/interface/storage.thrift
@@ -271,7 +271,7 @@ struct GetNeighborsResponse {
     //
     // The value of each tag column is a list of Values, which follows the order of the
     //   property names specified in the above column name. If a vertex does not have
-    //   the specific tag, the value will be NULL
+    //   the specific tag, the value will be empty value
     //
     // Columns after the tag columns are edge columns. One column per edge type. The
     //   column name is in the following format in the same order which specified in EdgeProp

--- a/src/common/interface/storage.thrift
+++ b/src/common/interface/storage.thrift
@@ -143,8 +143,8 @@ struct Expr {
 struct EdgeProp {
     // A valid edge type
     1: common.EdgeType  type,
-    // The list of property names. If it is empty, then all properties in both key and value will
-    // be returned. Support kSrc, kType, kRank and kDst as well.
+    // The list of property names. If it is empty, then all properties in value will be returned.
+    // Support kSrc, kType, kRank and kDst as well.
     2: list<binary>     props,
 }
 
@@ -153,8 +153,8 @@ struct EdgeProp {
 struct VertexProp {
     // A valid tag id
     1: common.TagID tag,
-    // The list of property names. If it is empty, then all properties in both key and value will
-    // be returned. Support kVid and kTag as well.
+    // The list of property names. If it is empty, then all properties in value will be returned.
+    // Support kVid and kTag as well.
     2: list<binary> props,
 }
 
@@ -613,7 +613,7 @@ struct ScanVertexRequest {
 struct ScanVertexResponse {
     1: required ResponseCommon              result,
     // The data will return as a dataset. The format is as follows:
-    // Each column represents one peoperty. the column name is in the form of "tag_name.prop_alias"
+    // Each column represents one property. the column name is in the form of "tag_name.prop_alias"
     // in the same order which specified in VertexProp in request.
     2: common.DataSet                       vertex_data,
     3: bool                                 has_next,
@@ -643,7 +643,7 @@ struct ScanEdgeRequest {
 struct ScanEdgeResponse {
     1: required ResponseCommon              result,
     // The data will return as a dataset. The format is as follows:
-    // Each column represents one peoperty. the column name is in the form of "tag_name.prop_alias"
+    // Each column represents one property. the column name is in the form of "edge_name.prop_alias"
     // in the same order which specified in EdgeProp in requesss.
     2: common.DataSet                       edge_data,
     3: bool                                 has_next,

--- a/src/common/interface/storage.thrift
+++ b/src/common/interface/storage.thrift
@@ -346,6 +346,9 @@ struct GetPropResponse {
     // Each column represents one peoperty. the column name is in the form of "tag_name.prop_alias"
     // or "edge_type_name.prop_alias" in the same order which specified in VertexProp or EdgeProp
     //
+    // If the request is to get tag prop, the first column will **always** be the vid,
+    // and the first column name is "_vid".
+    //
     // If the vertex or the edge does NOT have the given property, the value will be an empty value
     2: optional common.DataSet  props,
 }

--- a/src/common/interface/storage.thrift
+++ b/src/common/interface/storage.thrift
@@ -143,8 +143,8 @@ struct Expr {
 struct EdgeProp {
     // A valid edge type
     1: common.EdgeType  type,
-    // The list of property names. If it is empty, then all properties on
-    // the given edge type will be returned
+    // The list of property names. If it is empty, then all properties in both key and value will
+    // be returned. Support kSrc, kType, kRank and kDst as well.
     2: list<binary>     props,
 }
 
@@ -153,8 +153,8 @@ struct EdgeProp {
 struct VertexProp {
     // A valid tag id
     1: common.TagID tag,
-    // The list of property names. If it is empty, then all properties on
-    // the given tag will be returned
+    // The list of property names. If it is empty, then all properties in both key and value will
+    // be returned. Support kVid and kTag as well.
     2: list<binary> props,
 }
 
@@ -264,7 +264,8 @@ struct GetNeighborsResponse {
     //
     // Starting from the third column, source vertex properties will be returned if the
     //   GetNeighborsRequest::vertex_props is not empty. Each column contains properties
-    //   from one tag. The column name will be in the following format
+    //   from one tag. The column name will be in the following format in the same order
+    //   which specified in VertexProp
     //
     //   "_tag:<tag_name>:<alias1>:<alias2>:..."
     //
@@ -273,14 +274,14 @@ struct GetNeighborsResponse {
     //   the specific tag, the value will be NULL
     //
     // Columns after the tag columns are edge columns. One column per edge type. The
-    //   column name is in the following format
+    //   column name is in the following format in the same order which specified in EdgeProp
     //
     //   "_edge:<edge_name>:<alias1>:<alias2>:..."
     //
     // The value of each edge column is list<list<Value>>, which represents multiple
     //   edges. For each edge, the list of Values will follow the order of the property
     //   names specified in the column name. If a vertex does not have any edge for a
-    //   specific edge type, the value for that column will be NULL
+    //   specific edge type, the value for that column will be empty value
     //
     // The last column is the expression column, if the GetNeighborsRequest::expressions
     //   is not empty. The column name is in the format of this
@@ -307,27 +308,23 @@ struct ExecResponse {
  */
 struct GetPropRequest {
     1: common.GraphSpaceID                      space_id,
-    // Column names for the pass-in data. When getting the vertex props, the first
-    //   column has to be "_vid", when getting the edge props, the first four columns
-    //   have to be "_src", "_type", "_ranking", and "_dst"
-    2: list<binary>                             column_names,
-    3: map<common.PartitionID, list<common.Row>>
+    2: map<common.PartitionID, list<common.Row>>
         (cpp.template = "std::unordered_map")   parts,
     // Based on whether to get the vertex properties or to get the edge properties,
-    //   One of the following can be set. If an empty list is given then all properties
-    //   of the vertex or the edge will be returned
-    4: optional list<VertexProp>                vertex_props,
-    5: optional list<EdgeProp>                  edge_props,
+    // exactly one of the vertex_props or edge_props must be set. If an empty list is given
+    // then all properties of the vertex or the edge will be returned in tagId/edgeType ascending order
+    3: optional list<VertexProp>                vertex_props,
+    4: optional list<EdgeProp>                  edge_props,
     // A list of expressions with alias
-    6: optional list<Expr>                      expressions,
+    5: optional list<Expr>                      expressions,
     // Whether to do the dedup based on the entire result row
-    7: bool                                     dedup = false,
+    6: bool                                     dedup = false,
     // List of expressions used by the order-by clause
-    8: optional list<OrderBy>                   order_by,
-    9: optional i64                             limit,
+    7: optional list<OrderBy>                   order_by,
+    8: optional i64                             limit,
     // If a filter is provided, only vertices that are satisfied the filter
     // will be returned
-    10: optional binary                          filter,
+    9: optional binary                          filter,
 }
 
 
@@ -346,15 +343,10 @@ struct GetPropResponse {
     //   | .....                            |
     //   ====================================
     //
-    // If the request is to get tag prop, the first column will **always** be the vid,
-    // and the first column name is "_vid".
+    // Each column represents one peoperty. the column name is in the form of "tag_name.prop_alias"
+    // or "edge_type_name.prop_alias" in the same order which specified in VertexProp or EdgeProp
     //
-    // Each column represents one peoperty. When all properties are returned, the
-    //   column name is in the form of
-    //   "tag_name.prop_alias" or "edge_type_name.prop_alias"
-    //
-    // If the vertex or the edge does NOT have the given property, the value will
-    //   be a NULL
+    // If the vertex or the edge does NOT have the given property, the value will be an empty value
     2: optional common.DataSet  props,
 }
 /*
@@ -532,27 +524,15 @@ struct LookupIndexResp {
     //   properties; when looking up the edge index, each row represents one edge
     //   and its properties.
     //
-    // When returning the data for the vertex index, it follows this convention:
-    // 1. The name of the first column is "_vid", it's the ID of the vertex
-    // 2. Starting from the second column, it's the vertex property, one column
-    //    per peoperty. The column name is in the form of "tag_name.prop_name".
-    //    If the vertex does NOT have the given property, the value will be a NULL
-    //
-    // When returning the data for the edge index, it follows this convention:
-    // 1. The name of the first column is "_src", it's the ID of the source vertex
-    // 2. The name of the second column is "_ranking", it's the edge ranking
-    // 3. The name of the third column is "_dst", it's the ID of the destination
-    //    vertex
-    // 4. Starting from the fourth column, it's the edge property, one column per
-    //    peoperty. The column name is in the form of "edge_type_name.prop_name".
-    //    If the vertex does NOT have the given property, the value will be a NULL
+    // Each column represents one peoperty. the column name is in the form of "tag_name.prop_alias"
+    // or "edge_type_name.prop_alias" in the same order which specified in return_columns of request
     2: optional common.DataSet          data,
 }
 
- enum ScanType {
+enum ScanType {
     PREFIX = 1,
     RANGE  = 2,
- } (cpp.enum_strict)
+} (cpp.enum_strict)
 
 struct IndexColumnHint {
     1: binary                   column_name,
@@ -588,9 +568,8 @@ struct LookupIndexRequest {
     1: required common.GraphSpaceID         space_id,
     2: required list<common.PartitionID>    parts,
     3: IndexSpec                            indices,
-    // We only support specified fields here, not wild card "*"
-    // If the list is empty, only the VertexID or the EdgeKey will
-    // be returned
+    // The list of property names. Should not be empty.
+    // Support kVid and kTag for vertex, kSrc, kType, kRank and kDst for edge.
     4: optional list<binary>                return_columns,
 }
 
@@ -615,29 +594,24 @@ struct ScanVertexRequest {
     // start key of this block
     3: optional binary                      cursor,
     4: VertexProp                           return_columns,
-    // If no_columns is true, no properties of tags will be returned,
-    // no matter what property is defined in VertexProp
-    5: bool                                 no_columns,
     // max row count of tag in this response
-    6: i32                                  limit,
+    5: i32                                  limit,
     // only return data in time range [start_time, end_time)
-    7: optional i64                         start_time,
-    8: optional i64                         end_time,
-    9: optional binary                      filter,
+    6: optional i64                         start_time,
+    7: optional i64                         end_time,
+    8: optional binary                      filter,
     // when storage enable multi versions and only_latest_version is true, only return latest version.
     // when storage disable multi versions, just use the default value.
-    10: bool                                only_latest_version = false,
+    9: bool                                 only_latest_version = false,
     // if set to false, forbid follower read
-    11: bool                                enable_read_from_follower = true,
+    10: bool                                enable_read_from_follower = true,
 }
 
 struct ScanVertexResponse {
     1: required ResponseCommon              result,
     // The data will return as a dataset. The format is as follows:
-    // 1. First column is vertex id
-    // 2. Second column is tag id
-    // 3. Starting from the third column, is the properties specified in request.
-    //    If no_columns is true, there are only the first two columns.
+    // Each column represents one peoperty. the column name is in the form of "tag_name.prop_alias"
+    // in the same order which specified in VertexProp in request.
     2: common.DataSet                       vertex_data,
     3: bool                                 has_next,
     // next start key of scan, only valid when has_next is true
@@ -650,31 +624,24 @@ struct ScanEdgeRequest {
     // start key of this block
     3: optional binary                      cursor,
     4: EdgeProp                             return_columns,
-    // If no_columns is true, no properties of edge will be returned,
-    // no matter what property is defined in EdgeProp
-    5: bool                                 no_columns,
     // max row count of edge in this response
-    6: i32                                  limit,
+    5: i32                                  limit,
     // only return data in time range [start_time, end_time)
-    7: optional i64                         start_time,
-    8: optional i64                         end_time,
-    9: optional binary                      filter,
+    6: optional i64                         start_time,
+    7: optional i64                         end_time,
+    8: optional binary                      filter,
     // when storage enable multi versions and only_latest_version is true, only return latest version.
     // when storage disable multi versions, just use the default value.
-    10: bool                                only_latest_version = false,
+    9: bool                                only_latest_version = false,
     // if set to false, forbid follower read
-    11: bool                                enable_read_from_follower = true,
+    10: bool                                enable_read_from_follower = true,
 }
 
 struct ScanEdgeResponse {
     1: required ResponseCommon              result,
     // The data will return as a dataset. The format is as follows:
-    // 1. First column is src id
-    // 2. Second column is edge type
-    // 3. Third column is edge rank
-    // 4. Fourth column is dst id
-    // 5. Starting from the fifth column, is the properties specified in request.
-    //    If no_columns is true, there are only the first four columns.
+    // Each column represents one peoperty. the column name is in the form of "tag_name.prop_alias"
+    // in the same order which specified in EdgeProp in requesss.
     2: common.DataSet                       edge_data,
     3: bool                                 has_next,
     // next start key of scan, only valid when has_next is true


### PR DESCRIPTION
Explicit is better than implicit.

Previously, storage has many default return columns. For example, `fetch tag` will always return vid as first column. `lookup edge` will always return src, rank and dst as first three columns. This will cause many problems, for example, query engine will need to distinguish `DataSet` is from fetch or lookup. Both query engine and storage will have special cases to deal with.

In this PR:

1. *Storage will no more return any default columns. Any columns need to specified explicitly by query engine or client.*

    For example, you can specify `kVid`, `kTag` or any column in tag schema to get the property you want in `VertexProp`. And `kSrc/kType/kRank/kDst` and any column in edge schema in `EdgeProp`. 
    The return column of lookup will be specified in `return_columns` of `LookupIndexRequest`. They also follow above principles.

2. The column name in response is as follows: `tag_name.property` or `edge_name.property`. For example "tag1.col1", "tag1.kVid", "edge1.col3", "edge1.kDst", all column names in `fetch/lookup/scan` is the same. In `go`, the column name a different, the `Dataset` in `go` response is a more complicated one, please see the thrift,  but the property name format is same as other interface.

All interfaces have been unified, including `go`, `fetch`, `lookup`, `update` and `scan`.


