### PR TITLE
Fix logical expression

### DIFF
--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -2306,12 +2306,12 @@ Value operator||(const Value& lhs, const Value& rhs) {
 }
 
 Value operator&(const Value& lhs, const Value& rhs) {
-    if (lhs.isNull()) {
-        return lhs.getNull();
+    if (lhs.isNull() || (lhs.empty() && !rhs.isNull())) {
+        return lhs;
     }
 
-    if (rhs.isNull()) {
-        return rhs.getNull();
+    if (rhs.isNull() || rhs.empty()) {
+        return rhs;
     }
 
     if (lhs.type() != rhs.type()) {
@@ -2332,12 +2332,12 @@ Value operator&(const Value& lhs, const Value& rhs) {
 }
 
 Value operator|(const Value& lhs, const Value& rhs) {
-    if (lhs.isNull()) {
-        return lhs.getNull();
+    if (lhs.isNull() || (lhs.empty() && !rhs.isNull())) {
+        return lhs;
     }
 
-    if (rhs.isNull()) {
-        return rhs.getNull();
+    if (rhs.isNull() || rhs.empty()) {
+        return rhs;
     }
 
     if (lhs.type() != rhs.type()) {
@@ -2358,12 +2358,12 @@ Value operator|(const Value& lhs, const Value& rhs) {
 }
 
 Value operator^(const Value& lhs, const Value& rhs) {
-    if (lhs.isNull()) {
-        return lhs.getNull();
+    if (lhs.isNull() || (lhs.empty() && !rhs.isNull())) {
+        return lhs;
     }
 
-    if (rhs.isNull()) {
-        return rhs.getNull();
+    if (rhs.isNull() || rhs.empty()) {
+        return rhs;
     }
 
     if (lhs.type() != rhs.type()) {

--- a/src/common/datatypes/test/ValueTest.cpp
+++ b/src/common/datatypes/test/ValueTest.cpp
@@ -510,6 +510,8 @@ TEST(Value, Logical) {
 }
 
 TEST(Value, Bit) {
+    Value vNull(nebula::NullType::__NULL__);
+    Value vEmpty;
     Value vZero(0);
     Value vInt1(1);
     Value vInt2(2);
@@ -539,6 +541,18 @@ TEST(Value, Bit) {
 
         v = vDate1 & vDate2;
         EXPECT_TRUE(v.isNull());
+
+        v = vEmpty & vNull;
+        EXPECT_TRUE(v.isNull());
+
+        v = vEmpty & vEmpty;
+        EXPECT_TRUE(v.empty());
+
+        v = vNull & vNull;
+        EXPECT_TRUE(v.isNull());
+
+        v = vNull & vEmpty;
+        EXPECT_TRUE(v.isNull());
     }
 
     {
@@ -550,13 +564,25 @@ TEST(Value, Bit) {
         EXPECT_EQ(Value::Type::INT, v.type());
         EXPECT_EQ(1, v.getInt());
 
-        v = vStr1 & vStr2;
+        v = vStr1 | vStr2;
         EXPECT_TRUE(v.isNull());
 
-        v = vFloat1 & vFloat2;
+        v = vFloat1 | vFloat2;
         EXPECT_TRUE(v.isNull());
 
-        v = vDate1 & vDate2;
+        v = vDate1 | vDate2;
+        EXPECT_TRUE(v.isNull());
+
+        v = vEmpty | vNull;
+        EXPECT_TRUE(v.isNull());
+
+        v = vEmpty | vEmpty;
+        EXPECT_TRUE(v.empty());
+
+        v = vNull | vNull;
+        EXPECT_TRUE(v.isNull());
+
+        v = vNull | vEmpty;
         EXPECT_TRUE(v.isNull());
     }
 
@@ -569,13 +595,25 @@ TEST(Value, Bit) {
         EXPECT_EQ(Value::Type::INT, v.type());
         EXPECT_EQ(1, v.getInt());
 
-        v = vStr1 & vStr2;
+        v = vStr1 ^ vStr2;
         EXPECT_TRUE(v.isNull());
 
-        v = vFloat1 & vFloat2;
+        v = vFloat1 ^ vFloat2;
         EXPECT_TRUE(v.isNull());
 
-        v = vDate1 & vDate2;
+        v = vDate1 ^ vDate2;
+        EXPECT_TRUE(v.isNull());
+
+        v = vEmpty ^ vNull;
+        EXPECT_TRUE(v.isNull());
+
+        v = vEmpty ^ vEmpty;
+        EXPECT_TRUE(v.empty());
+
+        v = vNull ^ vNull;
+        EXPECT_TRUE(v.isNull());
+
+        v = vNull ^ vEmpty;
         EXPECT_TRUE(v.isNull());
     }
 }

--- a/src/common/datatypes/test/ValueTest.cpp
+++ b/src/common/datatypes/test/ValueTest.cpp
@@ -542,6 +542,30 @@ TEST(Value, Bit) {
         v = vDate1 & vDate2;
         EXPECT_TRUE(v.isNull());
 
+        v = vEmpty & true;
+        EXPECT_TRUE(v.empty());
+
+        v = vEmpty & false;
+        EXPECT_TRUE(v.empty());
+
+        v = true & vEmpty;
+        EXPECT_TRUE(v.empty());
+
+        v = false & vEmpty;
+        EXPECT_TRUE(v.empty());
+
+        v = vNull & true;
+        EXPECT_TRUE(v.isNull());
+
+        v = vNull & false;
+        EXPECT_TRUE(v.isNull());
+
+        v = true & vNull;
+        EXPECT_TRUE(v.isNull());
+
+        v = false & vNull;
+        EXPECT_TRUE(v.isNull());
+
         v = vEmpty & vNull;
         EXPECT_TRUE(v.isNull());
 
@@ -573,6 +597,31 @@ TEST(Value, Bit) {
         v = vDate1 | vDate2;
         EXPECT_TRUE(v.isNull());
 
+        v = vEmpty | true;
+        EXPECT_TRUE(v.empty());
+
+        v = vEmpty | false;
+        EXPECT_TRUE(v.empty());
+
+        v = true | vEmpty;
+        EXPECT_TRUE(v.empty());
+
+        v = false | vEmpty;
+        EXPECT_TRUE(v.empty());
+
+        v = vNull | true;
+        EXPECT_TRUE(v.isNull());
+
+        v = vNull | false;
+        EXPECT_TRUE(v.isNull());
+
+        v = true | vNull;
+        EXPECT_TRUE(v.isNull());
+
+        v = false | vNull;
+        EXPECT_TRUE(v.isNull());
+
+
         v = vEmpty | vNull;
         EXPECT_TRUE(v.isNull());
 
@@ -602,6 +651,30 @@ TEST(Value, Bit) {
         EXPECT_TRUE(v.isNull());
 
         v = vDate1 ^ vDate2;
+        EXPECT_TRUE(v.isNull());
+
+        v = vEmpty ^ true;
+        EXPECT_TRUE(v.empty());
+
+        v = vEmpty ^ false;
+        EXPECT_TRUE(v.empty());
+
+        v = true ^ vEmpty;
+        EXPECT_TRUE(v.empty());
+
+        v = false ^ vEmpty;
+        EXPECT_TRUE(v.empty());
+
+        v = vNull ^ true;
+        EXPECT_TRUE(v.isNull());
+
+        v = vNull ^ false;
+        EXPECT_TRUE(v.isNull());
+
+        v = true ^ vNull;
+        EXPECT_TRUE(v.isNull());
+
+        v = false ^ vNull;
         EXPECT_TRUE(v.isNull());
 
         v = vEmpty ^ vNull;

--- a/src/common/expression/LogicalExpression.cpp
+++ b/src/common/expression/LogicalExpression.cpp
@@ -29,7 +29,9 @@ const Value& LogicalExpression::evalAnd(ExpressionContext &ctx) {
         return result_;
     }
     if (!result_.isBool()) {
-        result_ = Value::kNullValue;
+        if (!result_.empty()) {
+            result_ = Value::kNullValue;
+        }
     }
 
     for (auto i = 1u; i < operands_.size(); i++) {
@@ -39,7 +41,11 @@ const Value& LogicalExpression::evalAnd(ExpressionContext &ctx) {
             return result_;
         }
         if (!result.isBool()) {
-            result_ = Value::kNullValue;
+            if (result.empty()) {
+                result_ = result;
+            } else {
+                result_ = Value::kNullValue;
+            }
             continue;
         }
         if (!result.getBool()) {
@@ -57,7 +63,9 @@ const Value& LogicalExpression::evalOr(ExpressionContext &ctx) {
         return result_;
     }
     if (!result_.isBool()) {
-        result_ = Value::kNullValue;
+        if (!result_.empty()) {
+            result_ = Value::kNullValue;
+        }
     }
 
     for (auto i = 0u; i < operands_.size(); i++) {
@@ -67,7 +75,11 @@ const Value& LogicalExpression::evalOr(ExpressionContext &ctx) {
             return result_;
         }
         if (!result.isBool()) {
-            result_ = Value::kNullValue;
+            if (result.empty()) {
+                result_ = result;
+            } else {
+                result_ = Value::kNullValue;
+            }
             continue;
         }
         if (result.getBool()) {
@@ -85,7 +97,9 @@ const Value& LogicalExpression::evalXor(ExpressionContext &ctx) {
         return result_;
     }
     if (!result_.isBool()) {
-        result_ = Value::kNullValue;
+        if (!result_.empty()) {
+            result_ = Value::kNullValue;
+        }
         return result_;
     }
     auto result = result_.getBool();
@@ -97,7 +111,11 @@ const Value& LogicalExpression::evalXor(ExpressionContext &ctx) {
             return result_;
         }
         if (!value.isBool()) {
-            result_ = Value::kNullValue;
+            if (value.empty()) {
+                result_ = value;
+            } else {
+                result_ = Value::kNullValue;
+            }
             return result_;
         }
         result = result ^ value.getBool();

--- a/src/common/expression/LogicalExpression.cpp
+++ b/src/common/expression/LogicalExpression.cpp
@@ -124,9 +124,7 @@ const Value& LogicalExpression::evalXor(ExpressionContext &ctx) {
             return result_;
         }
         if (!hasEmpty) {
-            bool bval = result.getBool() ^ value.getBool();
-            result = bval;
-            assert(result.isBool());
+            result = static_cast<bool>(result.getBool() ^ value.getBool());
         }
     }
 

--- a/src/common/expression/LogicalExpression.cpp
+++ b/src/common/expression/LogicalExpression.cpp
@@ -33,10 +33,13 @@ const Value& LogicalExpression::evalAnd(ExpressionContext &ctx) {
             return result_;
         }
         if (!value.isBool()) {
-            if (value.empty() && !result_.isNull()) {
+            if (value.isNull()) {
+                result_ = value;
+            } else if (value.empty() && !result_.isNull()) {
                 result_ = value;
             } else {
-                result_ = Value::kNullValue;
+                result_ = Value::kNullBadType;
+                return result_;
             }
         }
     }
@@ -54,10 +57,13 @@ const Value& LogicalExpression::evalOr(ExpressionContext &ctx) {
             return result_;
         }
         if (!value.isBool()) {
-            if (value.empty() && !result_.isNull()) {
+            if (value.isNull()) {
+                result_ = value;
+            } else if (value.empty() && !result_.isNull()) {
                 result_ = value;
             } else {
-                result_ = Value::kNullValue;
+                result_ = Value::kNullBadType;
+                return result_;
             }
         }
     }
@@ -80,7 +86,7 @@ const Value& LogicalExpression::evalXor(ExpressionContext &ctx) {
                 hasEmpty = 1;
                 continue;
             }
-            result_ = Value::kNullValue;
+            result_ = Value::kNullBadType;
             return result_;
         }
         if (hasEmpty) continue;

--- a/src/common/expression/LogicalExpression.cpp
+++ b/src/common/expression/LogicalExpression.cpp
@@ -23,6 +23,7 @@ const Value& LogicalExpression::eval(ExpressionContext& ctx) {
     }
 }
 
+// evalAnd short circuit logic: BADNULL == false > NULL >= EMPTY > true
 const Value& LogicalExpression::evalAnd(ExpressionContext &ctx) {
     result_ = true;
     for (auto i = 0u; i < operands_.size(); i++) {
@@ -47,6 +48,7 @@ const Value& LogicalExpression::evalAnd(ExpressionContext &ctx) {
     return result_;
 }
 
+// evalOr short circuit logic: BADNULL == true > NULL >= EMPTY > false
 const Value& LogicalExpression::evalOr(ExpressionContext &ctx) {
     result_ = false;
     for (auto i = 0u; i < operands_.size(); i++) {
@@ -71,6 +73,7 @@ const Value& LogicalExpression::evalOr(ExpressionContext &ctx) {
     return result_;
 }
 
+// evalXor short circuit logic: BADNULL == NULL > EMPTY > Bool
 const Value& LogicalExpression::evalXor(ExpressionContext &ctx) {
     auto hasEmpty = 0u;
     auto firstBool = 1u;

--- a/src/common/expression/LogicalExpression.cpp
+++ b/src/common/expression/LogicalExpression.cpp
@@ -26,6 +26,9 @@ const Value& LogicalExpression::eval(ExpressionContext& ctx) {
 const Value& LogicalExpression::evalAnd(ExpressionContext &ctx) {
     for (auto i = 0u; i < operands_.size(); i++) {
         result_ = operands_[i]->eval(ctx);
+        if (result_.isBadNull()) {
+            return result_;
+        }
         if (!result_.isBool()) {
             if (!result_.isNull()) {
                 result_ = Value::kNullValue;
@@ -43,11 +46,14 @@ const Value& LogicalExpression::evalAnd(ExpressionContext &ctx) {
 const Value& LogicalExpression::evalOr(ExpressionContext &ctx) {
     for (auto i = 0u; i < operands_.size(); i++) {
         result_ = operands_[i]->eval(ctx);
+        if (result_.isBadNull()) {
+            return result_;
+        }
         if (!result_.isBool()) {
             if (!result_.isNull()) {
                 result_ = Value::kNullValue;
             }
-            break;
+            continue;
         }
         if (result_.getBool()) {
             break;
@@ -59,6 +65,9 @@ const Value& LogicalExpression::evalOr(ExpressionContext &ctx) {
 
 const Value& LogicalExpression::evalXor(ExpressionContext &ctx) {
     result_ = operands_[0]->eval(ctx);
+    if (result_.isBadNull()) {
+        return result_;
+    }
     if (!result_.isBool()) {
         if (!result_.isNull()) {
             result_ = Value::kNullValue;

--- a/src/common/expression/LogicalExpression.cpp
+++ b/src/common/expression/LogicalExpression.cpp
@@ -81,20 +81,23 @@ const Value& LogicalExpression::evalOr(ExpressionContext &ctx) {
 
 const Value& LogicalExpression::evalXor(ExpressionContext &ctx) {
     result_ = operands_[0]->eval(ctx);
+    if (result_.isBadNull()) {
+        return result_;
+    }
     if (!result_.isBool()) {
-        if (!result_.isNull()) {
-            result_ = Value::kNullValue;
-        }
+        result_ = Value::kNullValue;
         return result_;
     }
     auto result = result_.getBool();
 
     for (auto i = 1u; i < operands_.size(); i++) {
         auto &value = operands_[i]->eval(ctx);
+        if (value.isBadNull()) {
+            result_ = value;
+            return result_;
+        }
         if (!value.isBool()) {
-            if (!value.isNull()) {
-                result_ = Value::kNullValue;
-            }
+            result_ = Value::kNullValue;
             return result_;
         }
         result = result ^ value.getBool();

--- a/src/common/expression/LogicalExpression.cpp
+++ b/src/common/expression/LogicalExpression.cpp
@@ -65,9 +65,6 @@ const Value& LogicalExpression::evalOr(ExpressionContext &ctx) {
 
 const Value& LogicalExpression::evalXor(ExpressionContext &ctx) {
     result_ = operands_[0]->eval(ctx);
-    if (result_.isBadNull()) {
-        return result_;
-    }
     if (!result_.isBool()) {
         if (!result_.isNull()) {
             result_ = Value::kNullValue;

--- a/src/common/expression/LogicalExpression.cpp
+++ b/src/common/expression/LogicalExpression.cpp
@@ -78,10 +78,8 @@ const Value& LogicalExpression::evalXor(ExpressionContext &ctx) {
         if (!value.isBool()) {
             if (!value.isNull()) {
                 result_ = Value::kNullValue;
-            } else {
-                result_ = value;
             }
-            break;
+            return result_;
         }
         result = result ^ value.getBool();
     }

--- a/src/common/expression/test/ExpressionTest.cpp
+++ b/src/common/expression/test/ExpressionTest.cpp
@@ -514,6 +514,26 @@ TEST_F(ExpressionTest, LogicalCalculation) {
         TEST_EXPR(2 > 1 AND 3 < 2, false);
         TEST_EXPR(2 < 1 AND 3 < 2, false);
     }
+    {
+        TEST_EXPR(2 / 0, Value::kNullValue);
+        TEST_EXPR(2 / 0 AND true, Value::kNullValue);
+        TEST_EXPR(2 / 0 AND false, Value::Value::kNullDivByZero);
+        TEST_EXPR(true AND 2 / 0, Value::kNullValue);
+        TEST_EXPR(false AND 2 / 0, false);
+        TEST_EXPR(2 / 0 AND 2 / 0, Value::kNullValue);
+
+        TEST_EXPR(2 / 0 OR true, Value::kNullValue);
+        TEST_EXPR(2 / 0 OR false, Value::kNullValue);
+        TEST_EXPR(true OR 2 / 0, true);
+        TEST_EXPR(false OR 2 / 0, Value::kNullValue);
+        TEST_EXPR(2 / 0 OR 2 / 0, Value::kNullValue);
+
+//        TEST_EXPR(2 / 0 XOR true, Value::kNullValue);
+//        TEST_EXPR(2 / 0 XOR false, Value::kNullValue);
+//        TEST_EXPR(true XOR 2 / 0, Value::kNullValue);
+//        TEST_EXPR(false XOR 2 / 0, Value::kNullValue);
+//        TEST_EXPR(2 / 0 XOR 2 / 0, Value::kNullValue);
+    }
 }
 
 TEST_F(ExpressionTest, LiteralConstantsRelational) {

--- a/src/common/expression/test/ExpressionTest.cpp
+++ b/src/common/expression/test/ExpressionTest.cpp
@@ -525,7 +525,7 @@ TEST_F(ExpressionTest, LogicalCalculation) {
         TEST_EXPR(true AND 2 / 0, Value::kNullDivByZero);
         TEST_EXPR(false AND 2 / 0, false);
         TEST_EXPR(2 / 0 AND 2 / 0, Value::kNullDivByZero);
-        TEST_EXPR(empty AND 2 AND 2 / 0 AND empty, Value::kNullDivByZero);
+        TEST_EXPR(empty AND null AND 2 / 0 AND empty, Value::kNullDivByZero);
 
         TEST_EXPR(2 / 0 OR true, Value::kNullDivByZero);
         TEST_EXPR(2 / 0 OR false, Value::kNullDivByZero);

--- a/src/common/expression/test/ExpressionTest.cpp
+++ b/src/common/expression/test/ExpressionTest.cpp
@@ -219,9 +219,11 @@ std::unordered_map<std::string, Expression::Kind> ExpressionTest::op_ = {
     {"!=", Expression::Kind::kRelNE},
     {"!", Expression::Kind::kUnaryNot}};
 
-std::unordered_map<std::string, Value> ExpressionTest::boolen_ = {{"true", Value(true)},
-                                                                  {"false", Value(false)},
-                                                                  {"empty", Value()}};
+std::unordered_map<std::string, Value>
+    ExpressionTest::boolen_ = {{"true", Value(true)},
+                               {"false", Value(false)},
+                               {"empty", Value()},
+                               {"null", Value(NullType::__NULL__)}};
 
 static std::unordered_map<std::string, std::vector<Value>> args_ = {
     {"null", {}},
@@ -530,36 +532,36 @@ TEST_F(ExpressionTest, LogicalCalculation) {
         TEST_EXPR(true OR 2 / 0, true);
         TEST_EXPR(false OR 2 / 0, Value::kNullDivByZero);
         TEST_EXPR(2 / 0 OR 2 / 0, Value::kNullDivByZero);
-        TEST_EXPR(empty OR 2 OR 2 / 0 OR empty, Value::kNullDivByZero);
+        TEST_EXPR(empty OR null OR 2 / 0 OR empty, Value::kNullDivByZero);
 
         TEST_EXPR(2 / 0 XOR true, Value::kNullDivByZero);
         TEST_EXPR(2 / 0 XOR false, Value::kNullDivByZero);
         TEST_EXPR(true XOR 2 / 0, Value::kNullDivByZero);
         TEST_EXPR(false XOR 2 / 0, Value::kNullDivByZero);
         TEST_EXPR(2 / 0 XOR 2 / 0, Value::kNullDivByZero);
-        TEST_EXPR(empty XOR 2 / 0 XOR 2 XOR empty, Value::kNullDivByZero);
+        TEST_EXPR(empty XOR 2 / 0 XOR null XOR empty, Value::kNullDivByZero);
 
         // test normal null
-        TEST_EXPR(2 AND true, Value::kNullValue);
-        TEST_EXPR(2 AND false, false);
-        TEST_EXPR(true AND 2, Value::kNullValue);
-        TEST_EXPR(false AND 2, false);
-        TEST_EXPR(2 AND 2, Value::kNullValue);
-        TEST_EXPR(empty AND 2 AND empty, Value::kNullValue);
+        TEST_EXPR(null AND true, Value::kNullValue);
+        TEST_EXPR(null AND false, false);
+        TEST_EXPR(true AND null, Value::kNullValue);
+        TEST_EXPR(false AND null, false);
+        TEST_EXPR(null AND null, Value::kNullValue);
+        TEST_EXPR(empty AND null AND empty, Value::kNullValue);
 
-        TEST_EXPR(2 OR true, true);
-        TEST_EXPR(2 OR false, Value::kNullValue);
-        TEST_EXPR(true OR 2, true);
-        TEST_EXPR(false OR 2, Value::kNullValue);
-        TEST_EXPR(2 OR 2, Value::kNullValue);
-        TEST_EXPR(empty OR 2 OR empty, Value::kNullValue);
+        TEST_EXPR(null OR true, true);
+        TEST_EXPR(null OR false, Value::kNullValue);
+        TEST_EXPR(true OR null, true);
+        TEST_EXPR(false OR null, Value::kNullValue);
+        TEST_EXPR(null OR null, Value::kNullValue);
+        TEST_EXPR(empty OR null OR empty, Value::kNullValue);
 
-        TEST_EXPR(2 XOR true, Value::kNullValue);
-        TEST_EXPR(2 XOR false, Value::kNullValue);
-        TEST_EXPR(true XOR 2, Value::kNullValue);
-        TEST_EXPR(false XOR 2, Value::kNullValue);
-        TEST_EXPR(2 XOR 2, Value::kNullValue);
-        TEST_EXPR(empty XOR 2 XOR empty, Value::kNullValue);
+        TEST_EXPR(null XOR true, Value::kNullValue);
+        TEST_EXPR(null XOR false, Value::kNullValue);
+        TEST_EXPR(true XOR null, Value::kNullValue);
+        TEST_EXPR(false XOR null, Value::kNullValue);
+        TEST_EXPR(null XOR null, Value::kNullValue);
+        TEST_EXPR(empty XOR null XOR empty, Value::kNullValue);
 
         // test empty
         TEST_EXPR(empty, Value::kEmpty);
@@ -568,8 +570,8 @@ TEST_F(ExpressionTest, LogicalCalculation) {
         TEST_EXPR(true AND empty, Value::kEmpty);
         TEST_EXPR(false AND empty, false);
         TEST_EXPR(empty AND empty, Value::kEmpty);
-        TEST_EXPR(empty AND 2, Value::kNullValue);
-        TEST_EXPR(2 AND empty, Value::kNullValue);
+        TEST_EXPR(empty AND null, Value::kNullValue);
+        TEST_EXPR(null AND empty, Value::kNullValue);
         TEST_EXPR(empty AND true AND empty, Value::kEmpty);
 
         TEST_EXPR(empty OR true, true);
@@ -577,8 +579,8 @@ TEST_F(ExpressionTest, LogicalCalculation) {
         TEST_EXPR(true OR empty, true);
         TEST_EXPR(false OR empty, Value::kEmpty);
         TEST_EXPR(empty OR empty, Value::kEmpty);
-        TEST_EXPR(empty OR 2, Value::kNullValue);
-        TEST_EXPR(2 OR empty, Value::kNullValue);
+        TEST_EXPR(empty OR null, Value::kNullValue);
+        TEST_EXPR(null OR empty, Value::kNullValue);
         TEST_EXPR(empty OR false OR empty, Value::kEmpty);
 
         TEST_EXPR(empty XOR true, Value::kEmpty);
@@ -586,18 +588,18 @@ TEST_F(ExpressionTest, LogicalCalculation) {
         TEST_EXPR(true XOR empty, Value::kEmpty);
         TEST_EXPR(false XOR empty, Value::kEmpty);
         TEST_EXPR(empty XOR empty, Value::kEmpty);
-        TEST_EXPR(empty XOR 2, Value::kNullValue);
-        TEST_EXPR(2 XOR empty, Value::kNullValue);
+        TEST_EXPR(empty XOR null, Value::kNullValue);
+        TEST_EXPR(null XOR empty, Value::kNullValue);
         TEST_EXPR(true XOR empty XOR false, Value::kEmpty);
 
-        TEST_EXPR(empty OR false AND true AND 2 XOR empty, Value::kEmpty);
+        TEST_EXPR(empty OR false AND true AND null XOR empty, Value::kEmpty);
         TEST_EXPR(empty OR false AND true XOR empty OR true, true);
-        TEST_EXPR((empty OR false) AND true XOR empty XOR 2 AND 2 / 0, Value::kNullValue);
+        TEST_EXPR((empty OR false) AND true XOR empty XOR null AND 2 / 0, Value::kNullValue);
         // empty OR false AND 2/0
-        TEST_EXPR(empty OR false AND true XOR empty XOR 2 AND 2 / 0, Value::kEmpty);
-        TEST_EXPR(empty AND true XOR empty XOR 2 AND 2 / 0, Value::kNullValue);
-        TEST_EXPR(empty OR false AND true XOR empty OR 2 AND 2 / 0, Value::kNullDivByZero);
-        TEST_EXPR(empty OR false AND empty XOR empty OR 2, Value::kNullValue);
+        TEST_EXPR(empty OR false AND true XOR empty XOR null AND 2 / 0, Value::kEmpty);
+        TEST_EXPR(empty AND true XOR empty XOR null AND 2 / 0, Value::kNullValue);
+        TEST_EXPR(empty OR false AND true XOR empty OR null AND 2 / 0, Value::kNullDivByZero);
+        TEST_EXPR(empty OR false AND empty XOR empty OR null, Value::kNullValue);
     }
 }
 

--- a/src/common/expression/test/ExpressionTest.cpp
+++ b/src/common/expression/test/ExpressionTest.cpp
@@ -515,24 +515,39 @@ TEST_F(ExpressionTest, LogicalCalculation) {
         TEST_EXPR(2 < 1 AND 3 < 2, false);
     }
     {
-        TEST_EXPR(2 / 0, Value::kNullValue);
-        TEST_EXPR(2 / 0 AND true, Value::kNullValue);
+        // test bad null
+        TEST_EXPR(2 / 0, Value::kNullDivByZero);
+        TEST_EXPR(2 / 0 AND true, Value::kNullDivByZero);
         TEST_EXPR(2 / 0 AND false, Value::Value::kNullDivByZero);
-        TEST_EXPR(true AND 2 / 0, Value::kNullValue);
+        TEST_EXPR(true AND 2 / 0, Value::kNullDivByZero);
         TEST_EXPR(false AND 2 / 0, false);
-        TEST_EXPR(2 / 0 AND 2 / 0, Value::kNullValue);
+        TEST_EXPR(2 / 0 AND 2 / 0, Value::kNullDivByZero);
 
-        TEST_EXPR(2 / 0 OR true, Value::kNullValue);
-        TEST_EXPR(2 / 0 OR false, Value::kNullValue);
+        TEST_EXPR(2 / 0 OR true, Value::kNullDivByZero);
+        TEST_EXPR(2 / 0 OR false, Value::kNullDivByZero);
         TEST_EXPR(true OR 2 / 0, true);
-        TEST_EXPR(false OR 2 / 0, Value::kNullValue);
-        TEST_EXPR(2 / 0 OR 2 / 0, Value::kNullValue);
+        TEST_EXPR(false OR 2 / 0, Value::kNullDivByZero);
+        TEST_EXPR(2 / 0 OR 2 / 0, Value::kNullDivByZero);
 
-        TEST_EXPR(2 / 0 XOR true, Value::kNullValue);
-        TEST_EXPR(2 / 0 XOR false, Value::kNullValue);
-        TEST_EXPR(true XOR 2 / 0, Value::kNullValue);
-        TEST_EXPR(false XOR 2 / 0, Value::kNullValue);
-        TEST_EXPR(2 / 0 XOR 2 / 0, Value::kNullValue);
+        // test normal null
+        TEST_EXPR(2 AND true, Value::kNullValue);
+        TEST_EXPR(2 AND false, false);
+        TEST_EXPR(true AND 2, Value::kNullValue);
+        TEST_EXPR(false AND 2, false);
+        TEST_EXPR(2 AND 2, Value::kNullValue);
+
+        TEST_EXPR(2 OR true, true);
+        TEST_EXPR(2 OR false, Value::kNullValue);
+        TEST_EXPR(true OR 2, true);
+        TEST_EXPR(false OR 2, Value::kNullValue);
+        TEST_EXPR(2 OR 2, Value::kNullValue);
+
+
+//        TEST_EXPR(2 / 0 XOR true, Value::kNullValue);
+//        TEST_EXPR(2 / 0 XOR false, Value::kNullValue);
+//        TEST_EXPR(true XOR 2 / 0, Value::kNullValue);
+//        TEST_EXPR(false XOR 2 / 0, Value::kNullValue);
+//        TEST_EXPR(2 / 0 XOR 2 / 0, Value::kNullValue);
     }
 }
 

--- a/src/common/expression/test/ExpressionTest.cpp
+++ b/src/common/expression/test/ExpressionTest.cpp
@@ -528,11 +528,11 @@ TEST_F(ExpressionTest, LogicalCalculation) {
         TEST_EXPR(false OR 2 / 0, Value::kNullValue);
         TEST_EXPR(2 / 0 OR 2 / 0, Value::kNullValue);
 
-//        TEST_EXPR(2 / 0 XOR true, Value::kNullValue);
-//        TEST_EXPR(2 / 0 XOR false, Value::kNullValue);
-//        TEST_EXPR(true XOR 2 / 0, Value::kNullValue);
-//        TEST_EXPR(false XOR 2 / 0, Value::kNullValue);
-//        TEST_EXPR(2 / 0 XOR 2 / 0, Value::kNullValue);
+        TEST_EXPR(2 / 0 XOR true, Value::kNullValue);
+        TEST_EXPR(2 / 0 XOR false, Value::kNullValue);
+        TEST_EXPR(true XOR 2 / 0, Value::kNullValue);
+        TEST_EXPR(false XOR 2 / 0, Value::kNullValue);
+        TEST_EXPR(2 / 0 XOR 2 / 0, Value::kNullValue);
     }
 }
 

--- a/src/common/expression/test/ExpressionTest.cpp
+++ b/src/common/expression/test/ExpressionTest.cpp
@@ -529,6 +529,12 @@ TEST_F(ExpressionTest, LogicalCalculation) {
         TEST_EXPR(false OR 2 / 0, Value::kNullDivByZero);
         TEST_EXPR(2 / 0 OR 2 / 0, Value::kNullDivByZero);
 
+        TEST_EXPR(2 / 0 XOR true, Value::kNullDivByZero);
+        TEST_EXPR(2 / 0 XOR false, Value::kNullDivByZero);
+        TEST_EXPR(true XOR 2 / 0, Value::kNullDivByZero);
+        TEST_EXPR(false XOR 2 / 0, Value::kNullDivByZero);
+        TEST_EXPR(2 / 0 XOR 2 / 0, Value::kNullDivByZero);
+
         // test normal null
         TEST_EXPR(2 AND true, Value::kNullValue);
         TEST_EXPR(2 AND false, false);
@@ -542,12 +548,11 @@ TEST_F(ExpressionTest, LogicalCalculation) {
         TEST_EXPR(false OR 2, Value::kNullValue);
         TEST_EXPR(2 OR 2, Value::kNullValue);
 
-
-//        TEST_EXPR(2 / 0 XOR true, Value::kNullValue);
-//        TEST_EXPR(2 / 0 XOR false, Value::kNullValue);
-//        TEST_EXPR(true XOR 2 / 0, Value::kNullValue);
-//        TEST_EXPR(false XOR 2 / 0, Value::kNullValue);
-//        TEST_EXPR(2 / 0 XOR 2 / 0, Value::kNullValue);
+        TEST_EXPR(2 XOR true, Value::kNullValue);
+        TEST_EXPR(2 XOR false, Value::kNullValue);
+        TEST_EXPR(true XOR 2, Value::kNullValue);
+        TEST_EXPR(false XOR 2, Value::kNullValue);
+        TEST_EXPR(2 XOR 2, Value::kNullValue);
     }
 }
 

--- a/src/common/expression/test/ExpressionTest.cpp
+++ b/src/common/expression/test/ExpressionTest.cpp
@@ -220,7 +220,8 @@ std::unordered_map<std::string, Expression::Kind> ExpressionTest::op_ = {
     {"!", Expression::Kind::kUnaryNot}};
 
 std::unordered_map<std::string, Value> ExpressionTest::boolen_ = {{"true", Value(true)},
-                                                                  {"false", Value(false)}};
+                                                                  {"false", Value(false)},
+                                                                  {"empty", Value()}};
 
 static std::unordered_map<std::string, std::vector<Value>> args_ = {
     {"null", {}},
@@ -522,18 +523,21 @@ TEST_F(ExpressionTest, LogicalCalculation) {
         TEST_EXPR(true AND 2 / 0, Value::kNullDivByZero);
         TEST_EXPR(false AND 2 / 0, false);
         TEST_EXPR(2 / 0 AND 2 / 0, Value::kNullDivByZero);
+        TEST_EXPR(empty AND 2 AND 2 / 0 AND empty, Value::kNullDivByZero);
 
         TEST_EXPR(2 / 0 OR true, Value::kNullDivByZero);
         TEST_EXPR(2 / 0 OR false, Value::kNullDivByZero);
         TEST_EXPR(true OR 2 / 0, true);
         TEST_EXPR(false OR 2 / 0, Value::kNullDivByZero);
         TEST_EXPR(2 / 0 OR 2 / 0, Value::kNullDivByZero);
+        TEST_EXPR(empty OR 2 OR 2 / 0 OR empty, Value::kNullDivByZero);
 
         TEST_EXPR(2 / 0 XOR true, Value::kNullDivByZero);
         TEST_EXPR(2 / 0 XOR false, Value::kNullDivByZero);
         TEST_EXPR(true XOR 2 / 0, Value::kNullDivByZero);
         TEST_EXPR(false XOR 2 / 0, Value::kNullDivByZero);
         TEST_EXPR(2 / 0 XOR 2 / 0, Value::kNullDivByZero);
+        TEST_EXPR(empty XOR 2 / 0 XOR 2 XOR empty, Value::kNullDivByZero);
 
         // test normal null
         TEST_EXPR(2 AND true, Value::kNullValue);
@@ -541,18 +545,59 @@ TEST_F(ExpressionTest, LogicalCalculation) {
         TEST_EXPR(true AND 2, Value::kNullValue);
         TEST_EXPR(false AND 2, false);
         TEST_EXPR(2 AND 2, Value::kNullValue);
+        TEST_EXPR(empty AND 2 AND empty, Value::kNullValue);
 
         TEST_EXPR(2 OR true, true);
         TEST_EXPR(2 OR false, Value::kNullValue);
         TEST_EXPR(true OR 2, true);
         TEST_EXPR(false OR 2, Value::kNullValue);
         TEST_EXPR(2 OR 2, Value::kNullValue);
+        TEST_EXPR(empty OR 2 OR empty, Value::kNullValue);
 
         TEST_EXPR(2 XOR true, Value::kNullValue);
         TEST_EXPR(2 XOR false, Value::kNullValue);
         TEST_EXPR(true XOR 2, Value::kNullValue);
         TEST_EXPR(false XOR 2, Value::kNullValue);
         TEST_EXPR(2 XOR 2, Value::kNullValue);
+        TEST_EXPR(empty XOR 2 XOR empty, Value::kNullValue);
+
+        // test empty
+        TEST_EXPR(empty, Value::kEmpty);
+        TEST_EXPR(empty AND true, Value::kEmpty);
+        TEST_EXPR(empty AND false, false);
+        TEST_EXPR(true AND empty, Value::kEmpty);
+        TEST_EXPR(false AND empty, false);
+        TEST_EXPR(empty AND empty, Value::kEmpty);
+        TEST_EXPR(empty AND 2, Value::kNullValue);
+        TEST_EXPR(2 AND empty, Value::kNullValue);
+        TEST_EXPR(empty AND true AND empty, Value::kEmpty);
+
+        TEST_EXPR(empty OR true, true);
+        TEST_EXPR(empty OR false, Value::kEmpty);
+        TEST_EXPR(true OR empty, true);
+        TEST_EXPR(false OR empty, Value::kEmpty);
+        TEST_EXPR(empty OR empty, Value::kEmpty);
+        TEST_EXPR(empty OR 2, Value::kNullValue);
+        TEST_EXPR(2 OR empty, Value::kNullValue);
+        TEST_EXPR(empty OR false OR empty, Value::kEmpty);
+
+        TEST_EXPR(empty XOR true, Value::kEmpty);
+        TEST_EXPR(empty XOR false, Value::kEmpty);
+        TEST_EXPR(true XOR empty, Value::kEmpty);
+        TEST_EXPR(false XOR empty, Value::kEmpty);
+        TEST_EXPR(empty XOR empty, Value::kEmpty);
+        TEST_EXPR(empty XOR 2, Value::kNullValue);
+        TEST_EXPR(2 XOR empty, Value::kNullValue);
+        TEST_EXPR(true XOR empty XOR false, Value::kEmpty);
+
+        TEST_EXPR(empty OR false AND true AND 2 XOR empty, Value::kEmpty);
+        TEST_EXPR(empty OR false AND true XOR empty OR true, true);
+        TEST_EXPR((empty OR false) AND true XOR empty XOR 2 AND 2 / 0, Value::kNullValue);
+        // empty OR false AND 2/0
+        TEST_EXPR(empty OR false AND true XOR empty XOR 2 AND 2 / 0, Value::kEmpty);
+        TEST_EXPR(empty AND true XOR empty XOR 2 AND 2 / 0, Value::kNullValue);
+        TEST_EXPR(empty OR false AND true XOR empty OR 2 AND 2 / 0, Value::kNullDivByZero);
+        TEST_EXPR(empty OR false AND empty XOR empty OR 2, Value::kNullValue);
     }
 }
 


### PR DESCRIPTION
This PR modified LogicalExpression's behavior from the following three aspects：
 
```
 - Fix the logical expression(AND/OR/XOR) behavior to be consistent with Cypher when null expression is involved, refer to `https://s3.amazonaws.com/artifacts.opencypher.org/openCypher9.pdf` (search label : `Logical operations with null`).

 - Add BadNull expression check

 - Add empty expression check

 - Add empty check for Value::operator&/|/^

```