### PR TITLE
fixed single quote error for fulltext index

### DIFF
--- a/src/common/plugin/fulltext/FTUtils.h
+++ b/src/common/plugin/fulltext/FTUtils.h
@@ -8,6 +8,7 @@
 #define COMMON_PLUGIN_FULLTEXT_UTILS_H_
 
 #include <iomanip>
+#include <boost/algorithm/string/replace.hpp>
 #include "common/base/Base.h"
 #include "common/datatypes/HostAddr.h"
 #include "common/encryption/MD5Utils.h"
@@ -21,6 +22,7 @@
 #define MAX_VALUE_LEN 255
 #define CURL_CONTENT_JSON " -H \"Content-Type: application/json; charset=utf-8\""
 #define CURL_CONTENT_NDJSON " -H \"Content-Type: application/x-ndjson; charset=utf-8\""
+#define ESCAPE_SINGLE_QUOTE  "\'\\\'\'"
 
 namespace nebula {
 namespace plugin {
@@ -180,6 +182,10 @@ struct DocIDTraits {
 
     static std::string val(const std::string &v) {
         return ((v.size() > MAX_VALUE_LEN) ? v.substr(0, MAX_VALUE_LEN) : v);
+    }
+
+    static std::string normalizedJson(const std::string &v) {
+        return boost::replace_all_copy(v, "'", ESCAPE_SINGLE_QUOTE);
     }
 
     static std::string docId(const DocItem& item) {

--- a/src/common/plugin/fulltext/elasticsearch/ESGraphAdapter.cpp
+++ b/src/common/plugin/fulltext/elasticsearch/ESGraphAdapter.cpp
@@ -133,7 +133,7 @@ std::string ESGraphAdapter::body(const DocItem& item,
                                                      ("size", maxRows)
                                                      ("from", 0);
     std::stringstream os;
-    os << " -d'" << folly::toJson(itemQuery) << "'";
+    os << " -d'" << DocIDTraits::normalizedJson(folly::toJson(itemQuery)) << "'";
     return os.str();
 }
 

--- a/src/common/plugin/fulltext/elasticsearch/ESStorageAdapter.cpp
+++ b/src/common/plugin/fulltext/elasticsearch/ESStorageAdapter.cpp
@@ -136,7 +136,8 @@ StatusOr<bool> ESStorageAdapter::bulk(const HttpClient& client,
     }
     auto ret = nebula::ProcessUtils::runCommand(command.c_str());
     if (!ret.ok() || ret.value().empty()) {
-        LOG(ERROR) << "Http PUT Failed";
+        VLOG(3) << "Http PUT Failed";
+        VLOG(3) << command;
         return Status::Error("bulk command failed");
     }
     return checkBulk(ret.value());
@@ -158,7 +159,7 @@ std::string ESStorageAdapter::putBody(const DocItem& item) const noexcept {
                                              ("column_id", DocIDTraits::column(item.column))
                                              ("value", DocIDTraits::val(item.val));
     std::stringstream os;
-    os << " -d'" << folly::toJson(d) << "'";
+    os << " -d'" << DocIDTraits::normalizedJson(folly::toJson(d)) << "'";
     return os.str();
 }
 
@@ -196,7 +197,7 @@ std::string ESStorageAdapter::bulkBody(const std::vector<DocItem>& items) const 
                                                     ("column_id", DocIDTraits::column(item.column))
                                                     ("schema_id", item.schema);
         os << folly::toJson(folly::dynamic::object("index", meta)) << "\n";
-        os << folly::toJson(data) << "\n";
+        os << DocIDTraits::normalizedJson(folly::toJson(data)) << "\n";
     }
     os << "'";
     return os.str();


### PR DESCRIPTION
Full-text index insert and scan will fail when single quotes appear in property values. reason is : 
The single quotes conflict  beteen `-d '` and `dev's`
invalid http body:
`-d '{"query": {"bool": {"must": [{"prefix": {"value": "dev's work"}}]}},"_source": ["value"],"from": 0,"size": 100}'`
valid http body:
`-d '{"query": {"bool": {"must": [{"prefix": {"value": "dev'\''s work"}}]}},"_source": ["value"],"from": 0,"size": 100}'`

- fixed the error as below : 

![image](https://user-images.githubusercontent.com/56461666/100875987-bc843900-34e1-11eb-802c-4d27eb70ac9b.png)
