### PR TITLE
if storage rpc return leader_change, but not set leader host, may core

### DIFF
--- a/src/common/clients/storage/StorageClientBase.h
+++ b/src/common/clients/storage/StorageClientBase.h
@@ -199,6 +199,10 @@ protected:
         return {req.get_part_id()};
     }
 
+    bool isValidHostPtr(const HostAddr* addr) {
+        return addr != nullptr && !addr->host.empty() && addr->port != 0;
+    }
+
 protected:
     meta::MetaClient* metaClient_{nullptr};
 

--- a/src/common/clients/storage/StorageClientBase.inl
+++ b/src/common/clients/storage/StorageClientBase.inl
@@ -245,7 +245,7 @@ StorageClientBase<ClientType>::collectResponse(
                             } else {
                                 invalidLeader(spaceId, code.get_part_id());
                             }
-                            if (retry < retryLimit) {
+                            if (retry < retryLimit && (leader != nullptr)) {
                                 evb->runAfterDelay([this, evb, leader = *leader, r = std::move(r),
                                                     remoteFunc = std::move(remoteFunc), context,
                                                     start, retry, retryLimit] () {
@@ -377,7 +377,7 @@ folly::Future<StatusOr<Response>> StorageClientBase<ClientType>::getResponse(
                     } else {
                         invalidLeader(spaceId, code.get_part_id());
                     }
-                    if (retry < retryLimit) {
+                    if (retry < retryLimit && (leader != nullptr)) {
                         evb->runAfterDelay([this, evb, leader = *leader,
                                             req = std::move(request.second),
                                             remoteFunc = std::move(remoteFunc), p = std::move(p),

--- a/src/common/clients/storage/StorageClientBase.inl
+++ b/src/common/clients/storage/StorageClientBase.inl
@@ -238,14 +238,12 @@ StorageClientBase<ClientType>::collectResponse(
                         hasFailure = true;
                         if (code.get_code() == storage::cpp2::ErrorCode::E_LEADER_CHANGED) {
                             auto* leader = code.get_leader();
-                            if (leader != nullptr &&
-                                !leader->host.empty() &&
-                                leader->port != 0) {
+                            if (isValidHostPtr(leader)) {
                                 updateLeader(spaceId, code.get_part_id(), *leader);
                             } else {
                                 invalidLeader(spaceId, code.get_part_id());
                             }
-                            if (retry < retryLimit && (leader != nullptr)) {
+                            if (retry < retryLimit && isValidHostPtr(leader)) {
                                 evb->runAfterDelay([this, evb, leader = *leader, r = std::move(r),
                                                     remoteFunc = std::move(remoteFunc), context,
                                                     start, retry, retryLimit] () {
@@ -370,14 +368,12 @@ folly::Future<StatusOr<Response>> StorageClientBase<ClientType>::getResponse(
                         << ", failed code " << static_cast<int32_t>(code.get_code());
                 if (code.get_code() == storage::cpp2::ErrorCode::E_LEADER_CHANGED) {
                     auto* leader = code.get_leader();
-                    if (leader != nullptr &&
-                        !leader->host.empty() &&
-                        leader->port != 0) {
+                    if (isValidHostPtr(leader)) {
                         updateLeader(spaceId, code.get_part_id(), *leader);
                     } else {
                         invalidLeader(spaceId, code.get_part_id());
                     }
-                    if (retry < retryLimit && (leader != nullptr)) {
+                    if (retry < retryLimit && isValidHostPtr(leader)) {
                         evb->runAfterDelay([this, evb, leader = *leader,
                                             req = std::move(request.second),
                                             remoteFunc = std::move(remoteFunc), p = std::move(p),


### PR DESCRIPTION
This may happen if an RPC arrived to a storage, whose leader is not elected. 