### PR TITLE
fix BitOp

### DIFF
--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -2314,14 +2314,11 @@ Value operator&(const Value& lhs, const Value& rhs) {
         return rhs;
     }
 
-    if (lhs.type() != rhs.type()) {
+    if (!lhs.isInt() || lhs.type() != rhs.type()) {
         return Value::kNullBadType;
     }
 
     switch (lhs.type()) {
-        case Value::Type::BOOL: {
-            return lhs.getBool() & rhs.getBool();
-        }
         case Value::Type::INT: {
             return lhs.getInt() & rhs.getInt();
         }
@@ -2340,14 +2337,11 @@ Value operator|(const Value& lhs, const Value& rhs) {
         return rhs;
     }
 
-    if (lhs.type() != rhs.type()) {
+    if (!lhs.isInt() || lhs.type() != rhs.type()) {
         return Value::kNullBadType;
     }
 
     switch (lhs.type()) {
-        case Value::Type::BOOL: {
-            return lhs.getBool() | rhs.getBool();
-        }
         case Value::Type::INT: {
             return lhs.getInt() | rhs.getInt();
         }
@@ -2366,14 +2360,11 @@ Value operator^(const Value& lhs, const Value& rhs) {
         return rhs;
     }
 
-    if (lhs.type() != rhs.type()) {
+    if (!lhs.isInt() || lhs.type() != rhs.type()) {
         return Value::kNullBadType;
     }
 
     switch (lhs.type()) {
-        case Value::Type::BOOL: {
-            return lhs.getBool() ^ rhs.getBool();
-        }
         case Value::Type::INT: {
             return lhs.getInt() ^ rhs.getInt();
         }

--- a/src/common/datatypes/test/ValueTest.cpp
+++ b/src/common/datatypes/test/ValueTest.cpp
@@ -530,8 +530,8 @@ TEST(Value, Bit) {
         EXPECT_EQ(0, v.getInt());
 
         v = vBool1 & vBool2;
-        EXPECT_EQ(Value::Type::INT, v.type());
-        EXPECT_EQ(0, v.getInt());
+        EXPECT_EQ(Value::Type::NULLVALUE, v.type());
+        EXPECT_EQ(NullType::BAD_TYPE, v.getNull());
 
         v = vStr1 & vStr2;
         EXPECT_TRUE(v.isNull());
@@ -585,8 +585,8 @@ TEST(Value, Bit) {
         EXPECT_EQ(3, v.getInt());
 
         v = vBool1 | vBool2;
-        EXPECT_EQ(Value::Type::INT, v.type());
-        EXPECT_EQ(1, v.getInt());
+        EXPECT_EQ(Value::Type::NULLVALUE, v.type());
+        EXPECT_EQ(NullType::BAD_TYPE, v.getNull());
 
         v = vStr1 | vStr2;
         EXPECT_TRUE(v.isNull());
@@ -641,8 +641,8 @@ TEST(Value, Bit) {
         EXPECT_EQ(3, v.getInt());
 
         v = vBool1 ^ vBool2;
-        EXPECT_EQ(Value::Type::INT, v.type());
-        EXPECT_EQ(1, v.getInt());
+        EXPECT_EQ(Value::Type::NULLVALUE, v.type());
+        EXPECT_EQ(NullType::BAD_TYPE, v.getNull());
 
         v = vStr1 ^ vStr2;
         EXPECT_TRUE(v.isNull());

--- a/src/common/function/AggregateFunction.h
+++ b/src/common/function/AggregateFunction.h
@@ -323,6 +323,10 @@ public:
         if (val.isNull() || val.empty()) {
             return;
         }
+        if (!val.isInt()) {
+            result_ = Value::kNullBadType;
+            return;
+        }
         if (distinct_) {
             uniques_.emplace(val);
         } else {
@@ -336,6 +340,7 @@ public:
     }
 
     Value getResult() override {
+        if (result_.isBadNull()) return result_;
         if (distinct_ && !uniques_.empty()) {
             Value result = *uniques_.begin();
             for (auto& v : uniques_) {
@@ -361,6 +366,10 @@ public:
         if (val.isNull() || val.empty()) {
             return;
         }
+        if (!val.isInt()) {
+            result_ = Value::kNullBadType;
+            return;
+        }
         if (distinct_) {
             uniques_.emplace(val);
         } else {
@@ -374,6 +383,7 @@ public:
     }
 
     Value getResult() override {
+        if (result_.isBadNull()) return result_;
         if (distinct_ && !uniques_.empty()) {
             Value result = *uniques_.begin();
             for (auto& v : uniques_) {
@@ -399,6 +409,10 @@ public:
         if (val.isNull() || val.empty()) {
             return;
         }
+        if (!val.isInt()) {
+            result_ = Value::kNullBadType;
+            return;
+        }
         if (distinct_) {
             uniques_.emplace(val);
         } else {
@@ -412,6 +426,9 @@ public:
     }
 
     Value getResult() override {
+        if (result_.isBadNull()) {
+            return result_;
+        }
         if (distinct_ && !uniques_.empty()) {
             Value result = *uniques_.begin();
             std::for_each(++uniques_.begin(), uniques_.end(), [&result] (auto& v) {

--- a/src/common/function/test/AggregateFunctionTest.cpp
+++ b/src/common/function/test/AggregateFunctionTest.cpp
@@ -20,6 +20,7 @@ public:
         vals4_.emplace_back(Value(NullType::__NULL__));
         vals4_.emplace_back(Value());
         vals5_ = {7, 3, 2, 3, 4, 1, 6, 7, 8, 5, 9, 0, 1};
+        vals6_ = {true, false, false, true};
     }
 protected:
     static std::vector<Value>  vals1_;
@@ -27,6 +28,7 @@ protected:
     static std::vector<Value>  vals3_;
     static std::vector<Value>  vals4_;
     static std::vector<Value>  vals5_;
+    static std::vector<Value>  vals6_;
 };
 
 std::vector<Value>  AggregateFunctionTest::vals1_;
@@ -34,6 +36,7 @@ std::vector<Value>  AggregateFunctionTest::vals2_;
 std::vector<Value>  AggregateFunctionTest::vals3_;
 std::vector<Value>  AggregateFunctionTest::vals4_;
 std::vector<Value>  AggregateFunctionTest::vals5_;
+std::vector<Value>  AggregateFunctionTest::vals6_;
 
 TEST_F(AggregateFunctionTest, Group) {
     auto group = AggFun::aggFunMap_[AggFun::Function::kNone](false);
@@ -376,6 +379,13 @@ TEST_F(AggregateFunctionTest, BitAnd) {
         EXPECT_EQ(bitAnd->getResult(), Value::kNullValue);
     }
     {
+        auto bitAnd = AggFun::aggFunMap_[AggFun::Function::kBitAnd](false);
+        for (auto& val : vals6_) {
+            bitAnd->apply(val);
+        }
+        EXPECT_EQ(bitAnd->getResult(), Value::kNullBadType);
+    }
+    {
         auto bitAnd = AggFun::aggFunMap_[AggFun::Function::kBitAnd](true);
         for (auto& val : vals1_) {
             bitAnd->apply(val);
@@ -403,6 +413,13 @@ TEST_F(AggregateFunctionTest, BitAnd) {
         }
         EXPECT_EQ(bitAnd->getResult(), 0);
     }
+    {
+        auto bitAnd = AggFun::aggFunMap_[AggFun::Function::kBitAnd](true);
+        for (auto& val : vals6_) {
+            bitAnd->apply(val);
+        }
+        EXPECT_EQ(bitAnd->getResult(), Value::kNullBadType);
+    }
 }
 
 TEST_F(AggregateFunctionTest, BitOr) {
@@ -426,6 +443,13 @@ TEST_F(AggregateFunctionTest, BitOr) {
             bitOr->apply(val);
         }
         EXPECT_EQ(bitOr->getResult(), Value::kNullValue);
+    }
+    {
+        auto bitOr = AggFun::aggFunMap_[AggFun::Function::kBitOr](false);
+        for (auto& val : vals6_) {
+            bitOr->apply(val);
+        }
+        EXPECT_EQ(bitOr->getResult(), Value::kNullBadType);
     }
     {
         auto bitOr = AggFun::aggFunMap_[AggFun::Function::kBitOr](true);
@@ -454,6 +478,13 @@ TEST_F(AggregateFunctionTest, BitOr) {
             bitOr->apply(val);
         }
         EXPECT_EQ(bitOr->getResult(), 15);
+    }
+    {
+        auto bitOr = AggFun::aggFunMap_[AggFun::Function::kBitOr](true);
+        for (auto& val : vals6_) {
+            bitOr->apply(val);
+        }
+        EXPECT_EQ(bitOr->getResult(), Value::kNullBadType);
     }
 }
 
@@ -480,6 +511,13 @@ TEST_F(AggregateFunctionTest, BitXor) {
         EXPECT_EQ(bitXor->getResult(), Value::kNullValue);
     }
     {
+        auto bitXor = AggFun::aggFunMap_[AggFun::Function::kBitXor](false);
+        for (auto& val : vals6_) {
+            bitXor->apply(val);
+        }
+        EXPECT_EQ(bitXor->getResult(), Value::kNullBadType);
+    }
+    {
         auto bitXor = AggFun::aggFunMap_[AggFun::Function::kBitXor](true);
         for (auto& val : vals1_) {
             bitXor->apply(val);
@@ -506,6 +544,13 @@ TEST_F(AggregateFunctionTest, BitXor) {
             bitXor->apply(val);
         }
         EXPECT_EQ(bitXor->getResult(), 1);
+    }
+    {
+        auto bitXor = AggFun::aggFunMap_[AggFun::Function::kBitXor](true);
+        for (auto& val : vals6_) {
+            bitXor->apply(val);
+        }
+        EXPECT_EQ(bitXor->getResult(), Value::kNullBadType);
     }
 }
 


### PR DESCRIPTION
This PR modify the behavior of operator&\|\^ and BIT_AND/BIT_OR/BIT_XOR.
For these bit operations, we currently only support `INT` type.
Related PR: [https://github.com/vesoft-inc/nebula-graph/pull/456](https://github.com/vesoft-inc/nebula-graph/pull/456)