### PR TITLE
getResponse throw not appropriate exception if leader changed

### DIFF
--- a/src/common/clients/storage/StorageClientBase.h
+++ b/src/common/clients/storage/StorageClientBase.h
@@ -134,11 +134,26 @@ protected:
             >
     folly::Future<StatusOr<Response>> getResponse(
             folly::EventBase* evb,
-            std::pair<HostAddr, Request> request,
-            RemoteFunc remoteFunc,
+            std::pair<HostAddr, Request>&& request,
+            RemoteFunc&& remoteFunc,
             folly::Promise<StatusOr<Response>> pro = folly::Promise<StatusOr<Response>>(),
             std::size_t retry = 0,
             std::size_t retryLimit = 3);
+
+    template<class Request,
+             class RemoteFunc,
+             class Response =
+                typename std::result_of<
+                    RemoteFunc(ClientType* client, const Request&)
+                >::type::value_type
+            >
+    void getResponseImpl(
+            folly::EventBase* evb,
+            std::pair<HostAddr, Request> request,
+            RemoteFunc remoteFunc,
+            folly::Promise<StatusOr<Response>> pro,
+            std::size_t retry,
+            std::size_t retryLimit);
 
     // Cluster given ids into the host they belong to
     // The method returns a map

--- a/src/common/clients/storage/StorageClientBase.inl
+++ b/src/common/clients/storage/StorageClientBase.inl
@@ -319,10 +319,29 @@ StorageClientBase<ClientType>::collectResponse(
     return context->promise.getSemiFuture();
 }
 
-
 template<typename ClientType>
 template<class Request, class RemoteFunc, class Response>
 folly::Future<StatusOr<Response>> StorageClientBase<ClientType>::getResponse(
+        folly::EventBase* evb,
+        std::pair<HostAddr, Request>&& request,
+        RemoteFunc&& remoteFunc,
+        folly::Promise<StatusOr<Response>> pro,
+        std::size_t retry,
+        std::size_t retryLimit) {
+    auto f = pro.getFuture();
+    getResponseImpl(evb,
+                std::forward<decltype(request)>(request),
+                std::forward<RemoteFunc>(remoteFunc),
+                std::move(pro),
+                retry,
+                retryLimit);
+    return f;
+}
+
+
+template<typename ClientType>
+template<class Request, class RemoteFunc, class Response>
+void StorageClientBase<ClientType>::getResponseImpl(
         folly::EventBase* evb,
         std::pair<HostAddr, Request> request,
         RemoteFunc remoteFunc,
@@ -333,7 +352,6 @@ folly::Future<StatusOr<Response>> StorageClientBase<ClientType>::getResponse(
         DCHECK(!!ioThreadPool_);
         evb = ioThreadPool_->getEventBase();
     }
-    auto f = pro.getFuture();
     folly::via(evb, [evb, request = std::move(request), remoteFunc = std::move(remoteFunc),
                      pro = std::move(pro), retry, retryLimit, this] () mutable {
         auto host = request.first;
@@ -375,17 +393,17 @@ folly::Future<StatusOr<Response>> StorageClientBase<ClientType>::getResponse(
                     }
                     if (retry < retryLimit && isValidHostPtr(leader)) {
                         evb->runAfterDelay([this, evb, leader = *leader,
-                                            req = std::move(request.second),
-                                            remoteFunc = std::move(remoteFunc), p = std::move(p),
-                                            retry, retryLimit] () mutable {
-                            getResponse(evb,
+                                req = std::move(request.second),
+                                remoteFunc = std::move(remoteFunc), p = std::move(p),
+                                retry, retryLimit] () mutable {
+                                getResponse(evb,
                                         std::pair<HostAddr, Request>(std::move(leader),
-                                                                     std::move(req)),
+                                            std::move(req)),
                                         std::move(remoteFunc),
                                         std::move(p),
                                         retry + 1,
                                         retryLimit);
-                        }, FLAGS_storage_client_retry_interval_ms);
+                                }, FLAGS_storage_client_retry_interval_ms);
                         return;
                     } else {
                         p.setValue(Status::LeaderChanged("Request to storage retry failed."));
@@ -399,7 +417,6 @@ folly::Future<StatusOr<Response>> StorageClientBase<ClientType>::getResponse(
             p.setValue(std::move(resp));
         });
     });  // via
-    return f;
 }
 
 

--- a/src/common/clients/storage/StorageClientBase.inl
+++ b/src/common/clients/storage/StorageClientBase.inl
@@ -396,7 +396,7 @@ void StorageClientBase<ClientType>::getResponseImpl(
                                 req = std::move(request.second),
                                 remoteFunc = std::move(remoteFunc), p = std::move(p),
                                 retry, retryLimit] () mutable {
-                                getResponse(evb,
+                                getResponseImpl(evb,
                                         std::pair<HostAddr, Request>(std::move(leader),
                                             std::move(req)),
                                         std::move(remoteFunc),


### PR DESCRIPTION
now getResponse() will call itself recursively. 
but in the second level. 
```
auto f = pro.getFuture(); 
```
will throw exception,  because get future from the same promise. 