### PR TITLE
Rename typename of containers in thrift

### DIFF
--- a/src/common/datatypes/ListOps.h
+++ b/src/common/datatypes/ListOps.h
@@ -52,7 +52,7 @@ template<>
 template<class Protocol>
 uint32_t Cpp2Ops<nebula::List>::write(Protocol* proto, nebula::List const* obj) {
     uint32_t xfer = 0;
-    xfer += proto->writeStructBegin("List");
+    xfer += proto->writeStructBegin("NList");
 
     xfer += proto->writeFieldBegin("values", apache::thrift::protocol::T_LIST, 1);
     xfer += detail::pm::protocol_methods<
@@ -134,7 +134,7 @@ template<class Protocol>
 uint32_t Cpp2Ops<nebula::List>::serializedSize(Protocol const* proto,
                                                nebula::List const* obj) {
     uint32_t xfer = 0;
-    xfer += proto->serializedStructSize("List");
+    xfer += proto->serializedStructSize("NList");
 
     xfer += proto->serializedFieldSize("values", apache::thrift::protocol::T_LIST, 1);
     xfer += detail::pm::protocol_methods<
@@ -151,7 +151,7 @@ template<class Protocol>
 uint32_t Cpp2Ops<nebula::List>::serializedSizeZC(Protocol const* proto,
                                                  nebula::List const* obj) {
     uint32_t xfer = 0;
-    xfer += proto->serializedStructSize("List");
+    xfer += proto->serializedStructSize("NList");
 
     xfer += proto->serializedFieldSize("values", apache::thrift::protocol::T_LIST, 1);
     xfer += detail::pm::protocol_methods<

--- a/src/common/datatypes/MapOps.h
+++ b/src/common/datatypes/MapOps.h
@@ -52,7 +52,7 @@ template<>
 template<class Protocol>
 uint32_t Cpp2Ops<nebula::Map>::write(Protocol* proto, nebula::Map const* obj) {
     uint32_t xfer = 0;
-    xfer += proto->writeStructBegin("Map");
+    xfer += proto->writeStructBegin("NMap");
 
     xfer += proto->writeFieldBegin("kvs", apache::thrift::protocol::T_MAP, 1);
     xfer += detail::pm::protocol_methods<
@@ -134,7 +134,7 @@ template<class Protocol>
 uint32_t Cpp2Ops<nebula::Map>::serializedSize(Protocol const* proto,
                                               nebula::Map const* obj) {
     uint32_t xfer = 0;
-    xfer += proto->serializedStructSize("Map");
+    xfer += proto->serializedStructSize("NMap");
 
     xfer += proto->serializedFieldSize("kvs", apache::thrift::protocol::T_MAP, 1);
     xfer += detail::pm::protocol_methods<
@@ -151,7 +151,7 @@ template<class Protocol>
 uint32_t Cpp2Ops<nebula::Map>::serializedSizeZC(Protocol const* proto,
                                                 nebula::Map const* obj) {
     uint32_t xfer = 0;
-    xfer += proto->serializedStructSize("Map");
+    xfer += proto->serializedStructSize("NMap");
 
     xfer += proto->serializedFieldSize("kvs", apache::thrift::protocol::T_MAP, 1);
     xfer += detail::pm::protocol_methods<

--- a/src/common/datatypes/SetOps.h
+++ b/src/common/datatypes/SetOps.h
@@ -52,7 +52,7 @@ template<>
 template<class Protocol>
 uint32_t Cpp2Ops<nebula::Set>::write(Protocol* proto, nebula::Set const* obj) {
     uint32_t xfer = 0;
-    xfer += proto->writeStructBegin("Set");
+    xfer += proto->writeStructBegin("NSet");
 
     xfer += proto->writeFieldBegin("values", apache::thrift::protocol::T_SET, 1);
     xfer += detail::pm::protocol_methods<
@@ -135,7 +135,7 @@ template<class Protocol>
 uint32_t Cpp2Ops<nebula::Set>::serializedSize(Protocol const* proto,
                                               nebula::Set const* obj) {
     uint32_t xfer = 0;
-    xfer += proto->serializedStructSize("Set");
+    xfer += proto->serializedStructSize("NSet");
     xfer += proto->serializedFieldSize("values", apache::thrift::protocol::T_SET, 1);
     xfer += detail::pm::protocol_methods<
             type_class::set<type_class::structure>,
@@ -151,7 +151,7 @@ template<class Protocol>
 uint32_t Cpp2Ops<nebula::Set>::serializedSizeZC(Protocol const* proto,
                                                 nebula::Set const* obj) {
     uint32_t xfer = 0;
-    xfer += proto->serializedStructSize("Set");
+    xfer += proto->serializedStructSize("NSet");
     xfer += proto->serializedFieldSize("values", apache::thrift::protocol::T_SET, 1);
     xfer += detail::pm::protocol_methods<
             type_class::set<type_class::structure>,

--- a/src/common/datatypes/ValueOps.h
+++ b/src/common/datatypes/ValueOps.h
@@ -211,7 +211,7 @@ uint32_t Cpp2Ops<nebula::Value>::write(Protocol* proto, nebula::Value const* obj
             if (obj->getListPtr()) {
                 xfer += Cpp2Ops<nebula::List>::write(proto, obj->getListPtr());
             } else {
-                xfer += proto->writeStructBegin("List");
+                xfer += proto->writeStructBegin("NList");
                 xfer += proto->writeStructEnd();
                 xfer += proto->writeFieldStop();
             }
@@ -224,7 +224,7 @@ uint32_t Cpp2Ops<nebula::Value>::write(Protocol* proto, nebula::Value const* obj
             if (obj->getMapPtr()) {
                 xfer += Cpp2Ops<nebula::Map>::write(proto, obj->getMapPtr());
             } else {
-                xfer += proto->writeStructBegin("Map");
+                xfer += proto->writeStructBegin("NMap");
                 xfer += proto->writeStructEnd();
                 xfer += proto->writeFieldStop();
             }
@@ -237,7 +237,7 @@ uint32_t Cpp2Ops<nebula::Value>::write(Protocol* proto, nebula::Value const* obj
             if (obj->getSetPtr()) {
                 xfer += Cpp2Ops<nebula::Set>::write(proto, obj->getSetPtr());
             } else {
-                xfer += proto->writeStructBegin("Set");
+                xfer += proto->writeStructBegin("NSet");
                 xfer += proto->writeStructEnd();
                 xfer += proto->writeFieldStop();
             }
@@ -575,7 +575,7 @@ uint32_t Cpp2Ops<nebula::Value>::serializedSize(Protocol const* proto,
             if (obj->getListPtr()) {
                 xfer += Cpp2Ops<nebula::List>::serializedSize(proto, obj->getListPtr());
             } else {
-                xfer += proto->serializedStructSize("List");
+                xfer += proto->serializedStructSize("NList");
                 xfer += proto->serializedSizeStop();
             }
             break;
@@ -586,7 +586,7 @@ uint32_t Cpp2Ops<nebula::Value>::serializedSize(Protocol const* proto,
             if (obj->getMapPtr()) {
                 xfer += Cpp2Ops<nebula::Map>::serializedSize(proto, obj->getMapPtr());
             } else {
-                xfer += proto->serializedStructSize("Map");
+                xfer += proto->serializedStructSize("NMap");
                 xfer += proto->serializedSizeStop();
             }
             break;
@@ -597,7 +597,7 @@ uint32_t Cpp2Ops<nebula::Value>::serializedSize(Protocol const* proto,
             if (obj->getSetPtr()) {
                 xfer += Cpp2Ops<nebula::Set>::serializedSize(proto, obj->getSetPtr());
             } else {
-                xfer += proto->serializedStructSize("Set");
+                xfer += proto->serializedStructSize("NSet");
                 xfer += proto->serializedSizeStop();
             }
             break;
@@ -729,7 +729,7 @@ uint32_t Cpp2Ops<nebula::Value>::serializedSizeZC(Protocol const* proto,
                 xfer += Cpp2Ops<nebula::List>
                     ::serializedSizeZC(proto, obj->getListPtr());
             } else {
-                xfer += proto->serializedStructSize("List");
+                xfer += proto->serializedStructSize("NList");
                 xfer += proto->serializedSizeStop();
             }
             break;
@@ -740,7 +740,7 @@ uint32_t Cpp2Ops<nebula::Value>::serializedSizeZC(Protocol const* proto,
             if (obj->getMapPtr()) {
                 xfer += Cpp2Ops<nebula::Map>::serializedSizeZC(proto, obj->getMapPtr());
             } else {
-                xfer += proto->serializedStructSize("Map");
+                xfer += proto->serializedStructSize("NMap");
                 xfer += proto->serializedSizeStop();
             }
             break;
@@ -751,7 +751,7 @@ uint32_t Cpp2Ops<nebula::Value>::serializedSizeZC(Protocol const* proto,
             if (obj->getSetPtr()) {
                 xfer += Cpp2Ops<nebula::Set>::serializedSizeZC(proto, obj->getSetPtr());
             } else {
-                xfer += proto->serializedStructSize("Set");
+                xfer += proto->serializedStructSize("NSet");
                 xfer += proto->serializedSizeStop();
             }
             break;

--- a/src/common/interface/common.thrift
+++ b/src/common/interface/common.thrift
@@ -101,27 +101,27 @@ union Value {
     9: Vertex (cpp.type = "nebula::Vertex")     vVal (cpp.ref_type = "unique");
     10: Edge (cpp.type = "nebula::Edge")        eVal (cpp.ref_type = "unique");
     11: Path (cpp.type = "nebula::Path")        pVal (cpp.ref_type = "unique");
-    12: List (cpp.type = "nebula::List")        lVal (cpp.ref_type = "unique");
-    13: Map (cpp.type = "nebula::Map")          mVal (cpp.ref_type = "unique");
-    14: Set (cpp.type = "nebula::Set")          uVal (cpp.ref_type = "unique");
+    12: NList (cpp.type = "nebula::List")       lVal (cpp.ref_type = "unique");
+    13: NMap (cpp.type = "nebula::Map")         mVal (cpp.ref_type = "unique");
+    14: NSet (cpp.type = "nebula::Set")         uVal (cpp.ref_type = "unique");
     15: DataSet (cpp.type = "nebula::DataSet")  gVal (cpp.ref_type = "unique");
 } (cpp.type = "nebula::Value")
 
 
 // Ordered list
-struct List {
+struct NList {
     1: list<Value> values;
 } (cpp.type = "nebula::List")
 
 
 // Unordered key/values pairs
-struct Map {
+struct NMap {
     1: map<binary, Value> (cpp.template = "std::unordered_map") kvs;
 } (cpp.type = "nebula::Map")
 
 
 // Unordered and unique values
-struct Set {
+struct NSet {
     1: set<Value> (cpp.template = "std::unordered_set") values;
 } (cpp.type = "nebula::Set")
 


### PR DESCRIPTION
Add prefix `N` to `List/Map/Set` to prevent naming conflicts. The only exception is C++ for the sake of minimal changes at the server side.

This PR will impact on all of our client API except C++, thus CI of nebula-graph due to nebula-python and nebula-console due to nebula-go