### PR TITLE
Support get vertex and edge property in storage client

### DIFF
--- a/src/common/clients/storage/GraphStorageClient.cpp
+++ b/src/common/clients/storage/GraphStorageClient.cpp
@@ -165,6 +165,34 @@ GraphStorageClient::addEdges(GraphSpaceID space,
 }
 
 folly::SemiFuture<StorageRpcResponse<cpp2::GetPropResponse>>
+GraphStorageClient::getVertexProps(GraphSpaceID space,
+                                   const DataSet& input,
+                                   const std::vector<cpp2::VertexProp>* vertexProps,
+                                   const std::vector<cpp2::Expr>* expressions,
+                                   bool dedup,
+                                   const std::vector<cpp2::OrderBy>& orderBy,
+                                   int64_t limit,
+                                   std::string filter,
+                                   folly::EventBase* evb) {
+    return getProps(space, input, vertexProps, nullptr, expressions,
+                    dedup, orderBy, limit, filter, evb);
+}
+
+folly::SemiFuture<StorageRpcResponse<cpp2::GetPropResponse>>
+GraphStorageClient::getEdgeProps(GraphSpaceID space,
+                                 const DataSet& input,
+                                 const std::vector<cpp2::EdgeProp>* edgeProps,
+                                 const std::vector<cpp2::Expr>* expressions,
+                                 bool dedup,
+                                 const std::vector<cpp2::OrderBy>& orderBy,
+                                 int64_t limit,
+                                 std::string filter,
+                                 folly::EventBase* evb) {
+    return getProps(space, input, nullptr, edgeProps, expressions,
+                    dedup, orderBy, limit, filter, evb);
+}
+
+folly::SemiFuture<StorageRpcResponse<cpp2::GetPropResponse>>
 GraphStorageClient::getProps(GraphSpaceID space,
                              const DataSet& input,
                              const std::vector<cpp2::VertexProp>* vertexProps,

--- a/src/common/clients/storage/GraphStorageClient.h
+++ b/src/common/clients/storage/GraphStorageClient.h
@@ -50,10 +50,20 @@ public:
         std::string filter = std::string(),
         folly::EventBase* evb = nullptr);
 
-    folly::SemiFuture<StorageRpcResponse<cpp2::GetPropResponse>> getProps(
+    folly::SemiFuture<StorageRpcResponse<cpp2::GetPropResponse>> getVertexProps(
         GraphSpaceID space,
         const DataSet& input,
         const std::vector<cpp2::VertexProp>* vertexProps,
+        const std::vector<cpp2::Expr>* expressions,
+        bool dedup = false,
+        const std::vector<cpp2::OrderBy>& orderBy = std::vector<cpp2::OrderBy>(),
+        int64_t limit = std::numeric_limits<int64_t>::max(),
+        std::string filter = std::string(),
+        folly::EventBase* evb = nullptr);
+
+    folly::SemiFuture<StorageRpcResponse<cpp2::GetPropResponse>> getEdgeProps(
+        GraphSpaceID space,
+        const DataSet& input,
         const std::vector<cpp2::EdgeProp>* edgeProps,
         const std::vector<cpp2::Expr>* expressions,
         bool dedup = false,
@@ -126,6 +136,18 @@ public:
         folly::EventBase* evb = nullptr);
 
 private:
+    folly::SemiFuture<StorageRpcResponse<cpp2::GetPropResponse>> getProps(
+        GraphSpaceID space,
+        const DataSet& input,
+        const std::vector<cpp2::VertexProp>* vertexProps,
+        const std::vector<cpp2::EdgeProp>* edgeProps,
+        const std::vector<cpp2::Expr>* expressions,
+        bool dedup = false,
+        const std::vector<cpp2::OrderBy>& orderBy = std::vector<cpp2::OrderBy>(),
+        int64_t limit = std::numeric_limits<int64_t>::max(),
+        std::string filter = std::string(),
+        folly::EventBase* evb = nullptr);
+
     StatusOr<std::function<const VertexID&(const Row&)>>
         getIdFromRow(GraphSpaceID space) const;
 


### PR DESCRIPTION
A small change about storage client, support get vertex and edge's property explicitly.