### PR TITLE
fixed metad dump when port already in use

### DIFF
--- a/src/common/webservice/WebService.cpp
+++ b/src/common/webservice/WebService.cpp
@@ -172,7 +172,7 @@ Status WebService::start() {
 
         if (!status.ok()) {
             LOG(ERROR) << "Failed to start web service: " << status;
-            wsThread_->join();
+            return status;
         }
     }
     return status;


### PR DESCRIPTION
fixed bug : NG-359

Metad crashed when http addr:port already in use.