### PR TITLE
Fix parallel thrift codegen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,7 @@ include(ClangTidy)
 # Remove the target exporting file
 file(REMOVE ${CMAKE_BINARY_DIR}/${PACKAGE_NAME}-config.cmake)
 
-# For simplicity, we make all ordinary libraries depend on the compile-time generated files,
-# including the precompiled header, a.k.a Base.h.gch, and thrift headers.
+# For simplicity, we make all ordinary libraries depend on the build-time generated files
 macro(nebula_add_library name type)
     add_library(${name} ${type} ${ARGN})
     export(
@@ -66,11 +65,11 @@ macro(nebula_add_library name type)
     )
     add_dependencies(
         ${name}
-        common_thrift_headers
-        graph_thrift_headers
-        storage_thrift_headers
-        meta_thrift_headers
-        raftex_thrift_headers
+        common_thrift_generator
+        graph_thrift_generator
+        storage_thrift_generator
+        meta_thrift_generator
+        raftex_thrift_generator
     )
 endmacro()
 

--- a/cmake/ThriftGenerate.cmake
+++ b/cmake/ThriftGenerate.cmake
@@ -92,12 +92,18 @@ add_custom_command(
   COMMENT "Generating thrift files for ${file_name}"
 )
 
-bypass_source_check(${file_name}_cpp2-SOURCES)
+bypass_source_check(${${file_name}-cpp2-SOURCES})
+add_custom_target(
+    ${file_name}_thrift_generator
+    DEPENDS ${${file_name}-cpp2-HEADERS} ${${file_name}-cpp2-SOURCES}
+)
+
 add_library(
   "${file_name}_thrift_obj"
   OBJECT
   ${${file_name}-cpp2-SOURCES}
 )
+add_dependencies(${file_name}_thrift_obj ${file_name}_thrift_generator)
 
 set_target_properties(
     "${file_name}_thrift_obj"
@@ -113,11 +119,17 @@ export(
   FILE ${CMAKE_BINARY_DIR}/${PACKAGE_NAME}-config.cmake
 )
 
-add_custom_target(${file_name}_thrift_headers DEPENDS ${${file_name}-cpp2-HEADERS})
 if(NOT "${file_name}" STREQUAL "common")
     add_dependencies(
-        "${file_name}_thrift_obj"
-        "common_thrift_obj"
+        ${file_name}_thrift_obj
+        common_thrift_generator
+    )
+endif()
+
+if("${file_name}" STREQUAL "storage")
+    add_dependencies(
+        ${file_name}_thrift_obj
+        meta_thrift_generator
     )
 endif()
 endmacro()


### PR DESCRIPTION
This PR fixes two issues:
 * Thrift codegen is performed multiple times in parallel build.
 * Storage related sources might be built twice even nothing changed.

The reasons are:
 * `add_custom_command` iteself does not introduce a target.
 * Multiple targets depend on the generated files, i.e. the generating procedure, while these targets don't depend on each other. So the codegen will be invoked in each depending chain.
 * storage.thrift depends on meta.thrift just like common.thrift, but the dependency is not addressed explicitly.