### PR TITLE
Remove the GIT_INFO_SHA definition from compile option

### DIFF
--- a/cmake/nebula/GitInfoConfig.cmake
+++ b/cmake/nebula/GitInfoConfig.cmake
@@ -1,12 +1,3 @@
-find_package(Git)
-if (GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-    execute_process(
-        COMMAND
-        ${GIT_EXECUTABLE} rev-parse --short HEAD
-        OUTPUT_VARIABLE GIT_INFO_SHA
-    )
-endif()
-
 if (GIT_INFO_SHA)
     string(REGEX REPLACE "[^0-9a-f]+" "" GIT_INFO_SHA "${GIT_INFO_SHA}")
     add_definitions(-DGIT_INFO_SHA=${GIT_INFO_SHA})


### PR DESCRIPTION
ccache use **the command line options** to compute the cache hash value, so if git info sha changes each time, it'll increase the cache misses for object files.