### PR TITLE
fix RelationalExpression

### DIFF
--- a/src/common/datatypes/Path.h
+++ b/src/common/datatypes/Path.h
@@ -116,6 +116,9 @@ struct Path {
     Path(const Path& p) = default;
     Path(Path&& p) noexcept
         : src(std::move(p.src)), steps(std::move(p.steps)) {}
+    Path(Vertex v, std::vector<Step> s)
+        : src(std::move(v))
+        , steps(std::move(s)) {}
 
     void clear() {
         src.clear();

--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -1629,6 +1629,182 @@ Value Value::toInt() {
     }
 }
 
+Value Value::lessThan(const Value& v) const {
+    if (empty() || v.empty()) {
+       return (v.isNull() || isNull())? Value::kNullValue : Value::kEmpty;
+    }
+    auto vType = v.type();
+    auto hasNull = (type_ | vType) & Value::Type::NULLVALUE;
+    auto notSameType = type_ != vType;
+    auto notBothNumeric = ((type_ | vType) & Value::kNumericType) != Value::kNumericType;
+    if (hasNull || (notSameType && notBothNumeric)) {
+        return Value::kNullValue;
+    }
+
+    switch (type_) {
+        case Value::Type::BOOL: {
+            return getBool() < v.getBool();
+        }
+        case Value::Type::INT: {
+            switch (vType) {
+                case Value::Type::INT: {
+                    return getInt() < v.getInt();
+                }
+                case Value::Type::FLOAT: {
+                    return (std::abs(getInt() - v.getFloat()) >= kEpsilon
+                            && getInt() < v.getFloat());
+                }
+                default: {
+                    return kNullBadType;
+                }
+            }
+        }
+        case Value::Type::FLOAT: {
+            switch (vType) {
+                case Value::Type::INT: {
+                    return (std::abs(getFloat() - v.getInt()) >= kEpsilon
+                            && getFloat() < v.getInt());
+                }
+                case Value::Type::FLOAT: {
+                    return (std::abs(getFloat() - v.getFloat()) >= kEpsilon
+                            && getFloat() < v.getFloat());
+                }
+                default: {
+                    return kNullBadType;
+                }
+            }
+        }
+        case Value::Type::STRING: {
+            return getStr() < v.getStr();
+        }
+        case Value::Type::DATE: {
+            return getDate() < v.getDate();
+        }
+        case Value::Type::TIME: {
+            // TODO(shylock) convert to UTC then compare
+            return getTime() < v.getTime();
+        }
+        case Value::Type::DATETIME: {
+            // TODO(shylock) convert to UTC then compare
+            return getDateTime() < v.getDateTime();
+        }
+        case Value::Type::VERTEX: {
+            return getVertex() < v.getVertex();
+        }
+        case Value::Type::EDGE: {
+            return getEdge() < v.getEdge();
+        }
+        case Value::Type::PATH: {
+            return getPath() < v.getPath();
+        }
+        case Value::Type::LIST: {
+            return getList() < v.getList();
+        }
+        case Value::Type::MAP: {
+            return getMap() < v.getMap();
+        }
+        case Value::Type::SET: {
+            return getSet() < v.getSet();
+        }
+        case Value::Type::DATASET: {
+            return getDataSet() < v.getDataSet();
+        }
+        case Value::Type::NULLVALUE:
+        case Value::Type::__EMPTY__: {
+            return kNullBadType;
+        }
+    }
+    DLOG(FATAL) << "Unknown type " << static_cast<int>(v.type());
+    return Value::kNullBadType;
+}
+
+Value Value::equal(const Value& v) const {
+    if (empty()) {
+       return v.isNull()? Value::kNullValue : v.empty();
+    }
+    auto vType = v.type();
+    auto hasNull = (type_ | vType) & Value::Type::NULLVALUE;
+    auto notSameType = type_ != vType;
+    auto notBothNumeric = ((type_ | vType) & Value::kNumericType) != Value::kNumericType;
+    if (hasNull) return Value::kNullValue;
+    if (notSameType && notBothNumeric) {
+        return false;
+    }
+
+    switch (type_) {
+        case Value::Type::BOOL: {
+            return getBool() == v.getBool();
+        }
+        case Value::Type::INT: {
+            switch (vType) {
+                case Value::Type::INT: {
+                    return getInt() == v.getInt();
+                }
+                case Value::Type::FLOAT: {
+                    return std::abs(getInt() - v.getFloat()) < kEpsilon;
+                }
+                default: {
+                    return kNullBadType;
+                }
+            }
+        }
+        case Value::Type::FLOAT: {
+            switch (vType) {
+                case Value::Type::INT: {
+                    return std::abs(getFloat() - v.getInt()) < kEpsilon;
+                }
+                case Value::Type::FLOAT: {
+                    return std::abs(getFloat() - v.getFloat()) < kEpsilon;
+                }
+                default: {
+                    return kNullBadType;
+                }
+            }
+        }
+        case Value::Type::STRING: {
+            return getStr() == v.getStr();
+        }
+        case Value::Type::DATE: {
+            return getDate() == v.getDate();
+        }
+        case Value::Type::TIME: {
+            // TODO(shylock) convert to UTC then compare
+            return getTime() == v.getTime();
+        }
+        case Value::Type::DATETIME: {
+            // TODO(shylock) convert to UTC then compare
+            return getDateTime() == v.getDateTime();
+        }
+        case Value::Type::VERTEX: {
+            return getVertex() == v.getVertex();
+        }
+        case Value::Type::EDGE: {
+            return getEdge() == v.getEdge();
+        }
+        case Value::Type::PATH: {
+            return getPath() == v.getPath();
+        }
+        case Value::Type::LIST: {
+            return getList() == v.getList();
+        }
+        case Value::Type::MAP: {
+            return getMap() == v.getMap();
+        }
+        case Value::Type::SET: {
+            return getSet() == v.getSet();
+        }
+        case Value::Type::DATASET: {
+            return getDataSet() == v.getDataSet();
+        }
+        case Value::Type::NULLVALUE:
+        case Value::Type::__EMPTY__: {
+            return false;
+        }
+    }
+    DLOG(FATAL) << "Unknown type " << static_cast<int>(v.type());
+    return Value::kNullBadType;
+}
+
 void swap(Value& a, Value& b) {
     Value temp(std::move(a));
     a = std::move(b);
@@ -2228,165 +2404,19 @@ Value operator!(const Value& rhs) {
 }
 
 bool operator<(const Value& lhs, const Value& rhs) {
-    auto lType = lhs.type();
-    auto rType = rhs.type();
-    auto hasNullOrEmpty = (lType | rType) & Value::kEmptyNullType;
-    auto notSameType = lType != rType;
-    auto notBothNumeric = ((lType | rType) & Value::kNumericType) != Value::kNumericType;
-    if (hasNullOrEmpty || (notSameType && notBothNumeric)) {
-        return lType < rType;
+    auto res = lhs.lessThan(rhs);
+    if (res.isBool()) {
+        return res.getBool();
     }
-
-    switch (lType) {
-        case Value::Type::BOOL: {
-            return lhs.getBool() < rhs.getBool();
-        }
-        case Value::Type::INT: {
-            switch (rType) {
-                case Value::Type::INT: {
-                    return lhs.getInt() < rhs.getInt();
-                }
-                case Value::Type::FLOAT: {
-                    return lhs.getInt() < rhs.getFloat();
-                }
-                default: {
-                    return false;
-                }
-            }
-        }
-        case Value::Type::FLOAT: {
-            switch (rType) {
-                case Value::Type::INT: {
-                    return lhs.getFloat() < rhs.getInt();
-                }
-                case Value::Type::FLOAT: {
-                    return lhs.getFloat() < rhs.getFloat();
-                }
-                default: {
-                    return false;
-                }
-            }
-        }
-        case Value::Type::STRING: {
-            return lhs.getStr() < rhs.getStr();
-        }
-        case Value::Type::VERTEX: {
-            return lhs.getVertex() < rhs.getVertex();
-        }
-        case Value::Type::EDGE: {
-            return lhs.getEdge() < rhs.getEdge();
-        }
-        case Value::Type::PATH: {
-            return lhs.getPath() < rhs.getPath();
-        }
-        case Value::Type::TIME: {
-            return lhs.getTime() < rhs.getTime();
-        }
-        case Value::Type::DATE: {
-            return lhs.getDate() < rhs.getDate();
-        }
-        case Value::Type::DATETIME: {
-            return lhs.getDateTime() < rhs.getDateTime();
-        }
-        case Value::Type::LIST: {
-            return lhs.getList() < rhs.getList();
-        }
-        case Value::Type::MAP:
-        case Value::Type::SET:
-        case Value::Type::DATASET: {
-            // TODO:
-            return false;
-        }
-        case Value::Type::NULLVALUE:
-        case Value::Type::__EMPTY__: {
-            return false;
-        }
-    }
-    DLOG(FATAL) << "Unknown type " << static_cast<int>(lType);
     return false;
 }
 
 bool operator==(const Value& lhs, const Value& rhs) {
-    auto lType = lhs.type();
-    auto rType = rhs.type();
-    auto hasNullOrEmpty = (lType | rType) & Value::kEmptyNullType;
-    auto notSameType = lType != rType;
-    auto notBothNumeric = ((lType | rType) & Value::kNumericType) != Value::kNumericType;
-    if (hasNullOrEmpty || (notSameType && notBothNumeric)) {
-        return lhs.type() == rhs.type();
+    if (lhs.isNull()) return rhs.isNull();
+    auto res = lhs.equal(rhs);
+    if (res.isBool()) {
+        return res.getBool();
     }
-
-    switch (lType) {
-        case Value::Type::BOOL: {
-            return lhs.getBool() == rhs.getBool();
-        }
-        case Value::Type::INT: {
-            switch (rType) {
-                case Value::Type::INT: {
-                    return lhs.getInt() == rhs.getInt();
-                }
-                case Value::Type::FLOAT: {
-                    return std::abs(lhs.getInt() - rhs.getFloat()) < kEpsilon;
-                }
-                default: {
-                    return false;
-                }
-            }
-        }
-        case Value::Type::FLOAT: {
-            switch (rType) {
-                case Value::Type::INT: {
-                    return std::abs(lhs.getFloat() - rhs.getInt()) < kEpsilon;
-                }
-                case Value::Type::FLOAT: {
-                    return std::abs(lhs.getFloat() - rhs.getFloat()) < kEpsilon;
-                }
-                default: {
-                    return false;
-                }
-            }
-        }
-        case Value::Type::STRING: {
-            return lhs.getStr() == rhs.getStr();
-        }
-        case Value::Type::DATE: {
-            return lhs.getDate() == rhs.getDate();
-        }
-        case Value::Type::TIME: {
-            // TODO(shylock) convert to UTC then compare
-            return lhs.getTime() == rhs.getTime();
-        }
-        case Value::Type::DATETIME: {
-            // TODO(shylock) convert to UTC then compare
-            return lhs.getDateTime() == rhs.getDateTime();
-        }
-        case Value::Type::VERTEX: {
-            return lhs.getVertex() == rhs.getVertex();
-        }
-        case Value::Type::EDGE: {
-            return lhs.getEdge() == rhs.getEdge();
-        }
-        case Value::Type::PATH: {
-            return lhs.getPath() == rhs.getPath();
-        }
-        case Value::Type::LIST: {
-            return lhs.getList() == rhs.getList();
-        }
-        case Value::Type::MAP: {
-            return lhs.getMap() == rhs.getMap();
-        }
-        case Value::Type::SET: {
-            return lhs.getSet() == rhs.getSet();
-        }
-        case Value::Type::DATASET: {
-            return lhs.getDataSet() == rhs.getDataSet();
-        }
-        case Value::Type::NULLVALUE:
-        case Value::Type::__EMPTY__: {
-            return false;
-        }
-    }
-    DLOG(FATAL) << "Unknown type " << static_cast<int>(lhs.type());
     return false;
 }
 
@@ -2415,6 +2445,10 @@ Value operator&&(const Value& lhs, const Value& rhs) {
         return rhs.getNull();
     }
 
+    if (lhs.empty() || rhs.empty()) {
+        return Value::kEmpty;
+    }
+
     if (lhs.type() == Value::Type::BOOL
             && rhs.type() == Value::Type::BOOL) {
         return lhs.getBool() && rhs.getBool();
@@ -2430,6 +2464,10 @@ Value operator||(const Value& lhs, const Value& rhs) {
 
     if (rhs.isNull()) {
         return rhs.getNull();
+    }
+
+    if (lhs.empty() || rhs.empty()) {
+        return Value::kEmpty;
     }
 
     if (lhs.type() == Value::Type::BOOL

--- a/src/common/datatypes/Value.h
+++ b/src/common/datatypes/Value.h
@@ -309,6 +309,10 @@ struct Value {
     Value toFloat();
     Value toInt();
 
+    Value lessThan(const Value& v) const;
+
+    Value equal(const Value& v) const;
+
 private:
     Type type_;
 

--- a/src/common/datatypes/test/ValueTest.cpp
+++ b/src/common/datatypes/test/ValueTest.cpp
@@ -270,7 +270,7 @@ TEST(Value, Comparison) {
 
         v = vInt1 < vNull;
         EXPECT_EQ(Value::Type::BOOL, v.type());
-        EXPECT_EQ(true, v.getBool());
+        EXPECT_EQ(false, v.getBool());
 
         v = vInt1 > vNull;
         EXPECT_EQ(Value::Type::BOOL, v.type());
@@ -286,7 +286,7 @@ TEST(Value, Comparison) {
 
         v = vInt1 > vEmpty;
         EXPECT_EQ(Value::Type::BOOL, v.type());
-        EXPECT_EQ(true, v.getBool());
+        EXPECT_EQ(false, v.getBool());
 
         v = vList1 > vList2;
         EXPECT_EQ(Value::Type::BOOL, v.type());
@@ -932,6 +932,9 @@ TEST(Value, DecodeEncode) {
         Value(Edge(001, 002, 1, "Edge", 233, {{"prop1", Value(233)}, {"prop2", Value(2.3)}})),
 
         // Path
+        Value(Path(
+            Vertex({"1", {Tag("tagName", {{"prop", Value(2)}})}}),
+            {Step(Vertex({"1", {Tag("tagName", {{"prop", Value(2)}})}}), 1, "1", 1, {{"1", 1}})})),
         Value(Path()),
 
         // List
@@ -953,6 +956,15 @@ TEST(Value, DecodeEncode) {
         Value valCopy;
         std::size_t s = serializer::deserialize(buf, valCopy);
         ASSERT_EQ(s, buf.size());
+        if (val.isNull()) {
+            EXPECT_EQ(valCopy.isNull(), true);
+            EXPECT_EQ(val.getNull(), valCopy.getNull());
+            continue;
+        }
+        if (val.empty()) {
+            EXPECT_EQ(valCopy.empty(), true);
+            continue;
+        }
         EXPECT_EQ(val, valCopy);
     }
 }

--- a/src/common/expression/RelationalExpression.cpp
+++ b/src/common/expression/RelationalExpression.cpp
@@ -15,31 +15,24 @@ const Value& RelationalExpression::eval(ExpressionContext& ctx) {
     auto& lhs = lhs_->eval(ctx);
     auto& rhs = rhs_->eval(ctx);
 
-    if (kind_ != Kind::kRelEQ && kind_ != Kind::kRelNE) {
-        auto lhsEmptyOrNull = lhs.type() & Value::kEmptyNullType;
-        auto rhsEmptyOrNull = rhs.type() & Value::kEmptyNullType;
-        if (lhsEmptyOrNull || rhsEmptyOrNull) {
-            return lhsEmptyOrNull ? lhs : rhs;
-        }
-    }
     switch (kind_) {
         case Kind::kRelEQ:
-            result_ = lhs == rhs;
+            result_ = lhs.equal(rhs);
             break;
         case Kind::kRelNE:
-            result_ = lhs != rhs;
+            result_ = !lhs.equal(rhs);
             break;
         case Kind::kRelLT:
-            result_ = lhs < rhs;
+            result_ = lhs.lessThan(rhs);
             break;
         case Kind::kRelLE:
-            result_ = lhs <= rhs;
+            result_ = lhs.lessThan(rhs) || lhs.equal(rhs);
             break;
         case Kind::kRelGT:
-            result_ = lhs > rhs;
+            result_ = !lhs.lessThan(rhs) && !lhs.equal(rhs);
             break;
         case Kind::kRelGE:
-            result_ = lhs >= rhs;
+            result_ = !lhs.lessThan(rhs) || lhs.equal(rhs);
             break;
         case Kind::kRelREG: {
             if (lhs.isStr() && rhs.isStr()) {

--- a/src/common/expression/test/ExpressionTest.cpp
+++ b/src/common/expression/test/ExpressionTest.cpp
@@ -179,8 +179,8 @@ protected:
         boost::split(splitString, expr, boost::is_any_of(" \t"));
         Expression *ep = ExpressionCalu(splitString);
         auto eval = Expression::eval(ep, gExpCtxt);
-        EXPECT_EQ(eval.type(), expected.type());
-        EXPECT_EQ(eval, expected);
+        EXPECT_EQ(eval.type(), expected.type()) << "type check failed: " << ep->toString();
+        EXPECT_EQ(eval, expected) << "check failed: " << ep->toString();
         delete ep;
     }
 
@@ -661,35 +661,35 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
         TEST_EXPR(true == 2.0, false);
         TEST_EXPR(true != 1.0, true);
         TEST_EXPR(true != 2.0, true);
-        TEST_EXPR(true > 1.0, false);
-        TEST_EXPR(true >= 1.0, false);
-        TEST_EXPR(true < 1.0, true);
-        TEST_EXPR(true <= 1.0, true);
+        TEST_EXPR(true > 1.0, Value::kNullBadType);
+        TEST_EXPR(true >= 1.0, Value::kNullBadType);
+        TEST_EXPR(true < 1.0, Value::kNullBadType);
+        TEST_EXPR(true <= 1.0, Value::kNullBadType);
         TEST_EXPR(false == 0.0, false);
         TEST_EXPR(false == 1.0, false);
         TEST_EXPR(false != 0.0, true);
         TEST_EXPR(false != 1.0, true);
-        TEST_EXPR(false > 0.0, false);
-        TEST_EXPR(false >= 0.0, false);
-        TEST_EXPR(false < 0.0, true);
-        TEST_EXPR(false <= 0.0, true);
+        TEST_EXPR(false > 0.0, Value::kNullBadType);
+        TEST_EXPR(false >= 0.0, Value::kNullBadType);
+        TEST_EXPR(false < 0.0, Value::kNullBadType);
+        TEST_EXPR(false <= 0.0, Value::kNullBadType);
 
         TEST_EXPR(true == 1, false);
         TEST_EXPR(true == 2, false);
         TEST_EXPR(true != 1, true);
         TEST_EXPR(true != 2, true);
-        TEST_EXPR(true > 1, false);
-        TEST_EXPR(true >= 1, false);
-        TEST_EXPR(true < 1, true);
-        TEST_EXPR(true <= 1, true);
+        TEST_EXPR(true > 1, Value::kNullBadType);
+        TEST_EXPR(true >= 1, Value::kNullBadType);
+        TEST_EXPR(true < 1, Value::kNullBadType);
+        TEST_EXPR(true <= 1, Value::kNullBadType);
         TEST_EXPR(false == 0, false);
         TEST_EXPR(false == 1, false);
         TEST_EXPR(false != 0, true);
         TEST_EXPR(false != 1, true);
-        TEST_EXPR(false > 0, false);
-        TEST_EXPR(false >= 0, false);
-        TEST_EXPR(false < 0, true);
-        TEST_EXPR(false <= 0, true);
+        TEST_EXPR(false > 0, Value::kNullBadType);
+        TEST_EXPR(false >= 0, Value::kNullBadType);
+        TEST_EXPR(false < 0, Value::kNullBadType);
+        TEST_EXPR(false <= 0, Value::kNullBadType);
     }
     {
         TEST_EXPR(-1 == -2, false);
@@ -740,6 +740,22 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
         TEST_EXPR(1 >= 1, true);
         TEST_EXPR(1 < 1, false);
         TEST_EXPR(1 <= 1, true);
+    }
+    {
+        TEST_EXPR(empty == empty, true);
+        TEST_EXPR(empty == null, Value::kNullValue);
+        TEST_EXPR(empty != null, Value::kNullValue);
+        TEST_EXPR(empty != 1, true);
+        TEST_EXPR(empty != true, true);
+        TEST_EXPR(empty > "1", Value::kEmpty);
+        TEST_EXPR(empty < 1, Value::kEmpty);
+        TEST_EXPR(empty >= 1.11, Value::kEmpty);
+
+        TEST_EXPR(null != 1, Value::kNullValue);
+        TEST_EXPR(null != true, Value::kNullValue);
+        TEST_EXPR(null > "1", Value::kNullValue);
+        TEST_EXPR(null < 1, Value::kNullValue);
+        TEST_EXPR(null >= 1.11, Value::kNullValue);
     }
     {
         TEST_EXPR(8 % 2 + 1 == 1, true);
@@ -964,8 +980,7 @@ TEST_F(ExpressionTest, Relation) {
                 new EdgePropertyExpression(new std::string("e1"), new std::string("list")),
                 new ConstantExpression(Value(NullType::NaN)));
         auto eval = Expression::eval(&expr, gExpCtxt);
-        EXPECT_EQ(eval.type(), Value::Type::BOOL);
-        EXPECT_EQ(eval, false);
+        EXPECT_EQ(eval.type(), Value::Type::NULLVALUE);
     }
     {
         // e1.list_of_list == NULL
@@ -974,8 +989,7 @@ TEST_F(ExpressionTest, Relation) {
                 new EdgePropertyExpression(new std::string("e1"), new std::string("list_of_list")),
                 new ConstantExpression(Value(NullType::NaN)));
         auto eval = Expression::eval(&expr, gExpCtxt);
-        EXPECT_EQ(eval.type(), Value::Type::BOOL);
-        EXPECT_EQ(eval, false);
+        EXPECT_EQ(eval.type(), Value::Type::NULLVALUE);
     }
     {
         // e1.list == e1.list
@@ -1004,8 +1018,7 @@ TEST_F(ExpressionTest, Relation) {
                 new ConstantExpression(Value(1)),
                 new ConstantExpression(Value(NullType::NaN)));
         auto eval = Expression::eval(&expr, gExpCtxt);
-        EXPECT_EQ(eval.type(), Value::Type::BOOL);
-        EXPECT_EQ(eval, false);
+        EXPECT_EQ(eval.type(), Value::Type::NULLVALUE);
     }
     {
         // NULL == NULL
@@ -1014,8 +1027,7 @@ TEST_F(ExpressionTest, Relation) {
                 new ConstantExpression(Value(NullType::NaN)),
                 new ConstantExpression(Value(NullType::NaN)));
         auto eval = Expression::eval(&expr, gExpCtxt);
-        EXPECT_EQ(eval.type(), Value::Type::BOOL);
-        EXPECT_EQ(eval, true);
+        EXPECT_EQ(eval.type(), Value::Type::NULLVALUE);
     }
     {
         // 1 != NULL
@@ -1024,8 +1036,7 @@ TEST_F(ExpressionTest, Relation) {
                 new ConstantExpression(Value(1)),
                 new ConstantExpression(Value(NullType::NaN)));
         auto eval = Expression::eval(&expr, gExpCtxt);
-        EXPECT_EQ(eval.type(), Value::Type::BOOL);
-        EXPECT_EQ(eval, true);
+        EXPECT_EQ(eval.type(), Value::Type::NULLVALUE);
     }
     {
         // NULL != NULL
@@ -1034,8 +1045,7 @@ TEST_F(ExpressionTest, Relation) {
                 new ConstantExpression(Value(NullType::NaN)),
                 new ConstantExpression(Value(NullType::NaN)));
         auto eval = Expression::eval(&expr, gExpCtxt);
-        EXPECT_EQ(eval.type(), Value::Type::BOOL);
-        EXPECT_EQ(eval, false);
+        EXPECT_EQ(eval.type(), Value::Type::NULLVALUE);
     }
     {
         // 1 < NULL


### PR DESCRIPTION
This PR fixes some bugs about Value comparison related to `null` and `empty`.  Fixes https://github.com/vesoft-inc/nebula-graph/issues/644
There are some test cases:
 - 2>true : null   2<=true : null
 - 2==true : false
 - null==true : null
 - null<>null : null
 - empty==empty : true
 - empty==null : null
 - empty>=1 : empty
