### PR TITLE
Fix TypeCastExpression

### DIFF
--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -1550,86 +1550,81 @@ std::string Value::toString() const {
     LOG(FATAL) << "Unknown value type " << static_cast<int>(type_);
 }
 
-std::pair<bool, bool> Value::toBool() {
+Value Value::toBool() {
     switch (type_) {
-        // Type::__EMPTY__ is always false
-        case Value::Type::__EMPTY__: {
-            return std::make_pair(false, true);
-        }
-        // Type::NULLVALUE is always false
+        case Value::Type::__EMPTY__:
         case Value::Type::NULLVALUE: {
-            return std::make_pair(false, true);
+            return Value::kNullValue;
         }
         case Value::Type::BOOL: {
-            return std::make_pair(getBool(), true);
-        }
-        case Value::Type::INT: {
-            return std::make_pair(getInt() != 0, true);
-        }
-        case Value::Type::FLOAT: {
-            return std::make_pair(std::abs(getFloat()) > kEpsilon, true);
+            return *this;
         }
         case Value::Type::STRING: {
-            return std::make_pair(!getStr().empty(), true);
-        }
-        case Value::Type::DATE: {
-            return std::make_pair(getDate().toInt() != 0, true);
+            auto str = toString();
+            std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+            if (str.compare("true") == 0) {
+                return true;
+            }
+            if (str.compare("false") == 0) {
+                return false;
+            }
+            return Value::kNullValue;
         }
         default: {
-            return std::make_pair(bool{}, false);
+            return Value::kNullBadType;
         }
     }
 }
 
-std::pair<double, bool> Value::toFloat() {
+Value Value::toFloat() {
     switch (type_) {
         case Value::Type::INT: {
-            return std::make_pair(static_cast<double>(getInt()), true);
+            return static_cast<double>(getInt());
         }
         case Value::Type::FLOAT: {
-            return std::make_pair(getFloat(), true);
+            return *this;
         }
         case Value::Type::STRING: {
             const auto& str = getStr();
             char *pEnd;
             double val = strtod(str.c_str(), &pEnd);
             if (*pEnd != '\0') {
-                return std::make_pair(double{}, false);
+                return Value::kNullValue;
             }
-            return std::make_pair(val, true);
+            return val;
         }
         default: {
-            return std::make_pair(double{}, false);
+            return Value::kNullBadType;
         }
     }
 }
 
-std::pair<int64_t, bool> Value::toInt() {
+Value Value::toInt() {
     switch (type_) {
         case Value::Type::INT: {
-            return std::make_pair(getInt(), true);
+            return *this;
         }
         case Value::Type::FLOAT: {
             // Check if float value is in the range of int_64
             // Return min/max int_64 value and false to accommodate Cypher
             if (getFloat() <= std::numeric_limits<int64_t>::min()) {
-                return std::make_pair(std::numeric_limits<int64_t>::min(), true);
+                return std::numeric_limits<int64_t>::min();
             } else if (getFloat() >= std::numeric_limits<int64_t>::max()) {
-                return std::make_pair(std::numeric_limits<int64_t>::max(), true);
+                return std::numeric_limits<int64_t>::max();
             }
-            return std::make_pair(static_cast<int64_t>(getFloat()), true);
+            return static_cast<int64_t>(getFloat());
         }
         case Value::Type::STRING: {
             const auto& str = getStr();
             char *pEnd;
             double val = strtod(str.c_str(), &pEnd);
             if (*pEnd != '\0') {
-                return std::make_pair(int64_t{}, false);
+                return Value::kNullValue;
             }
-            return std::make_pair(static_cast<int64_t>(val), true);
+            return static_cast<int64_t>(val);
         }
         default: {
-            return std::make_pair(int64_t{}, false);
+            return Value::kNullBadType;
         }
     }
 }

--- a/src/common/datatypes/Value.h
+++ b/src/common/datatypes/Value.h
@@ -305,12 +305,9 @@ struct Value {
 
     std::string toString() const;
 
-    // The second means is this casting valid, check it before access the value
-    std::pair<bool, bool> toBool();
-
-    std::pair<double, bool> toFloat();
-
-    std::pair<int64_t, bool> toInt();
+    Value toBool();
+    Value toFloat();
+    Value toInt();
 
 private:
     Type type_;

--- a/src/common/datatypes/test/ValueTest.cpp
+++ b/src/common/datatypes/test/ValueTest.cpp
@@ -549,6 +549,122 @@ TEST(Value, Logical) {
     }
 }
 
+TEST(Value, TypeCast) {
+    Value vInt(1);
+    Value vFloat(3.14);
+    Value vStr1("TrUe");
+    Value vStr2("3.14");
+    Value vBool1(false);
+    Value vBool2(true);
+    Value vDate(Date(2020, 1, 1));
+    Value vNull(NullType::__NULL__);
+    Value vIntMin(std::numeric_limits<int64_t>::min());
+    Value vIntMax(std::numeric_limits<int64_t>::max());
+    Value vFloatMin(std::numeric_limits<double_t>::lowest());   // non-negtive
+    Value vFloatMax(std::numeric_limits<double_t>::max());
+
+    {
+        auto vb1 = vInt.toBool();
+        EXPECT_EQ(Value::Type::NULLVALUE, vb1.type());
+
+        auto vb2 = vFloat.toBool();
+        EXPECT_EQ(Value::Type::NULLVALUE, vb2.type());
+
+        auto vb3 = vStr1.toBool();
+        EXPECT_EQ(Value::Type::BOOL, vb3.type());
+        EXPECT_EQ(true, vb3.getBool());
+
+        auto vb4 = vStr2.toBool();
+        EXPECT_EQ(Value::Type::NULLVALUE, vb4.type());
+
+        auto vb5 = vBool1.toBool();
+        EXPECT_EQ(Value::Type::BOOL, vb5.type());
+        EXPECT_EQ(false, vb5.getBool());
+
+        auto vb6 = vBool2.toBool();
+        EXPECT_EQ(Value::Type::BOOL, vb6.type());
+        EXPECT_EQ(true, vb6.getBool());
+
+        auto vb7 = vDate.toBool();
+        EXPECT_EQ(Value::Type::NULLVALUE, vb7.type());
+
+        auto vb8 = vNull.toBool();
+        EXPECT_EQ(Value::Type::NULLVALUE, vb8.type());
+    }
+    {
+        auto vf1 = vInt.toFloat();
+        EXPECT_EQ(Value::Type::FLOAT, vf1.type());
+        EXPECT_EQ(vf1.getFloat(), 1.0);
+
+        auto vf2 = vFloat.toFloat();
+        EXPECT_EQ(Value::Type::FLOAT, vf2.type());
+        EXPECT_EQ(vf2.getFloat(), 3.14);
+
+        auto vf3 = vStr1.toFloat();
+        EXPECT_EQ(Value::Type::NULLVALUE, vf3.type());
+
+        auto vf4 = vStr2.toFloat();
+        EXPECT_EQ(Value::Type::FLOAT, vf4.type());
+        EXPECT_EQ(vf4.getFloat(), 3.14);
+
+        auto vf5 = vBool1.toFloat();
+        EXPECT_EQ(Value::Type::NULLVALUE, vf5.type());
+
+        auto vf6 = vBool2.toFloat();
+        EXPECT_EQ(Value::Type::NULLVALUE, vf6.type());
+
+        auto vf7 = vDate.toFloat();
+        EXPECT_EQ(Value::Type::NULLVALUE, vf7.type());
+
+        auto vf8 = vNull.toFloat();
+        EXPECT_EQ(Value::Type::NULLVALUE, vf8.type());
+
+        auto vf9 = vIntMin.toFloat();
+        EXPECT_EQ(Value::Type::FLOAT, vf9.type());
+        EXPECT_EQ(vf9.getFloat(), std::numeric_limits<int64_t>::min());
+
+        auto vf10 = vIntMax.toFloat();
+        EXPECT_EQ(Value::Type::FLOAT, vf10.type());
+        EXPECT_EQ(vf10.getFloat(), std::numeric_limits<int64_t>::max());
+    }
+    {
+        auto vi1 = vInt.toInt();
+        EXPECT_EQ(Value::Type::INT, vi1.type());
+        EXPECT_EQ(vi1.getInt(), 1);
+
+        auto vi2 = vFloat.toInt();
+        EXPECT_EQ(Value::Type::INT, vi2.type());
+        EXPECT_EQ(vi2.getInt(), 3);
+
+        auto vi3 = vStr1.toInt();
+        EXPECT_EQ(Value::Type::NULLVALUE, vi3.type());
+
+        auto vi4 = vStr2.toInt();
+        EXPECT_EQ(Value::Type::INT, vi4.type());
+        EXPECT_EQ(vi4.getInt(), 3);
+
+        auto vi5 = vBool1.toInt();
+        EXPECT_EQ(Value::Type::NULLVALUE, vi5.type());
+
+        auto vi6 = vBool2.toInt();
+        EXPECT_EQ(Value::Type::NULLVALUE, vi6.type());
+
+        auto vi7 = vDate.toInt();
+        EXPECT_EQ(Value::Type::NULLVALUE, vi7.type());
+
+        auto vi8 = vNull.toInt();
+        EXPECT_EQ(Value::Type::NULLVALUE, vi8.type());
+
+        auto vi9 = vFloatMin.toInt();
+        EXPECT_EQ(Value::Type::INT, vi9.type());
+        EXPECT_EQ(vi9.getInt(), std::numeric_limits<int64_t>::min());
+
+        auto vi10 = vFloatMax.toInt();
+        EXPECT_EQ(Value::Type::INT, vi10.type());
+        EXPECT_EQ(vi10.getInt(), std::numeric_limits<int64_t>::max());
+    }
+}
+
 TEST(Value, Bit) {
     Value vNull(nebula::NullType::__NULL__);
     Value vEmpty;
@@ -838,120 +954,6 @@ TEST(Value, DecodeEncode) {
         std::size_t s = serializer::deserialize(buf, valCopy);
         ASSERT_EQ(s, buf.size());
         EXPECT_EQ(val, valCopy);
-    }
-}
-
-TEST(Value, TypeCast) {
-    Value vInt1(1);
-    Value vInt2(-1);
-    Value vIntMin(std::numeric_limits<int64_t>::min());
-    Value vIntMax(std::numeric_limits<int64_t>::max());
-    Value vFloat1(3.14);
-    Value vFloat2(10.0);
-    Value vFloatMin(std::numeric_limits<double_t>::min());   // non-negtive
-    Value vFloatMax(std::numeric_limits<double_t>::max());
-    Value vStr1("50");
-    Value vStr2("3.14");
-    Value vStr3("World");
-
-    // int to float
-    {
-        // 1
-        bool castSucceed = vInt1.toFloat().second;
-        EXPECT_EQ(true, castSucceed);
-        Value vIntToFloat = vInt1.toFloat().first;
-        EXPECT_EQ(Value::Type::FLOAT, vIntToFloat.type());
-        // -1
-        castSucceed = vIntMax.toFloat().second;
-        EXPECT_EQ(true, castSucceed);
-        vIntToFloat = vIntMax.toFloat().first;
-        EXPECT_EQ(Value::Type::FLOAT, vIntToFloat.type());
-    }
-    // int to string
-    {
-        Value vIntToStr = vInt1.toString();
-        EXPECT_EQ("1", vIntToStr);
-
-        vIntToStr = vInt2.toString();
-        EXPECT_EQ("-1", vIntToStr);
-
-        vIntToStr = vIntMax.toString();
-        EXPECT_EQ("9223372036854775807", vIntToStr);
-
-        vIntToStr = vIntMin.toString();
-        EXPECT_EQ("-9223372036854775808", vIntToStr);
-    }
-    // float to int
-    {
-        // 3.14
-        bool castSucceed = vFloat1.toInt().second;
-        EXPECT_EQ(true, castSucceed);
-        Value vFloatToInt = vFloat1.toInt().first;
-        EXPECT_EQ(Value::Type::INT, vFloatToInt.type());
-        // 10.0
-        castSucceed = vFloat2.toInt().second;
-        EXPECT_EQ(true, castSucceed);
-        vFloatToInt = vFloat2.toInt().first;
-        EXPECT_EQ(Value::Type::INT, vFloatToInt.type());
-        EXPECT_EQ(10, vFloatToInt);
-        // 1.7976931348623157E308
-        castSucceed = vFloatMax.toInt().second;
-        EXPECT_EQ(true, castSucceed);
-        EXPECT_EQ(std::numeric_limits<int64_t>::max(), vFloatMax.toInt().first);
-
-        castSucceed = vFloatMin.toInt().second;
-        EXPECT_EQ(true, castSucceed);
-        // -1.7976931348623157E308
-        castSucceed = (-vFloatMax).toInt().second;
-        EXPECT_EQ(true, castSucceed);
-        EXPECT_EQ(std::numeric_limits<int64_t>::min(), (-vFloatMax).toInt().first);
-    }
-    // float to string
-    {
-        Value vFloatToStr = vFloat1.toString();
-        EXPECT_EQ("3.14", vFloatToStr);
-
-        vFloatToStr = vFloatMax.toString();
-        EXPECT_EQ("1.7976931348623157E308", vFloatToStr);
-
-        vFloatToStr = (-vFloatMax).toString();
-        EXPECT_EQ("-1.7976931348623157E308", vFloatToStr);
-    }
-    // string to int
-    {
-        // "1"
-        bool castSucceed = vStr1.toInt().second;
-        EXPECT_EQ(true, castSucceed);
-        Value vStrToInt = vStr1.toInt().first;
-        EXPECT_EQ(Value::Type::INT, vStrToInt.type());
-        EXPECT_EQ(50, vStrToInt);
-        // "3.14"
-        castSucceed = vStr2.toInt().second;
-        EXPECT_EQ(true, castSucceed);
-        vStrToInt = vStr2.toInt().first;
-        EXPECT_EQ(Value::Type::INT, vStrToInt.type());
-        EXPECT_EQ(3, vStrToInt);   // lose precision
-        // "world"
-        castSucceed = vStr3.toInt().second;
-        EXPECT_EQ(false, castSucceed);
-    }
-    // string to float
-    {
-        // "50"
-        bool castSucceed = vStr1.toFloat().second;
-        EXPECT_EQ(true, castSucceed);
-        Value vStrToFloat = vStr1.toFloat().first;
-        EXPECT_EQ(Value::Type::FLOAT, vStrToFloat.type());
-        EXPECT_EQ(50.0, vStrToFloat);
-        // "3.14"
-        castSucceed = vStr2.toFloat().second;
-        EXPECT_EQ(true, castSucceed);
-        vStrToFloat = vStr2.toFloat().first;
-        EXPECT_EQ(Value::Type::FLOAT, vStrToFloat.type());
-        EXPECT_EQ(3.14, vStrToFloat);
-        // "world"
-        castSucceed = vStr3.toFloat().second;
-        EXPECT_EQ(false, castSucceed);
     }
 }
 }  // namespace nebula

--- a/src/common/expression/TypeCastingExpression.cpp
+++ b/src/common/expression/TypeCastingExpression.cpp
@@ -60,31 +60,20 @@ bool TypeCastingExpression::validateTypeCast(Value::Type operandType, Value::Typ
 }
 
 const Value& TypeCastingExpression::eval(ExpressionContext& ctx) {
+    DCHECK(!!operand_);
     auto val = operand_->eval(ctx);
 
     switch (vType_) {
         case Value::Type::BOOL: {
-            auto result = val.toBool();
-            if (!result.second) {
-                return Value::kNullValue;
-            }
-            result_.setBool(result.first);
+            result_ = val.toBool();
             break;
         }
         case Value::Type::INT: {
-            auto result = val.toInt();
-            if (!result.second) {
-                return Value::kNullValue;
-            }
-            result_.setInt(result.first);
+            result_ = val.toInt();
             break;
         }
         case Value::Type::FLOAT: {
-            auto result = val.toFloat();
-            if (!result.second) {
-                return Value::kNullValue;
-            }
-            result_.setFloat(result.first);
+            result_ = val.toFloat();
             break;
         }
         case Value::Type::STRING: {

--- a/src/common/expression/test/ExpressionTest.cpp
+++ b/src/common/expression/test/ExpressionTest.cpp
@@ -2113,14 +2113,12 @@ TEST_F(ExpressionTest, TypeCastTest) {
     {
         TypeCastingExpression typeCast(Value::Type::BOOL, new ConstantExpression(2));
         auto eval = Expression::eval(&typeCast, gExpCtxt);
-        EXPECT_EQ(eval.type(), Value::Type::BOOL);
-        EXPECT_EQ(eval, true);
+        EXPECT_EQ(eval.type(), Value::Type::NULLVALUE);
     }
     {
         TypeCastingExpression typeCast(Value::Type::BOOL, new ConstantExpression(0));
         auto eval = Expression::eval(&typeCast, gExpCtxt);
-        EXPECT_EQ(eval.type(), Value::Type::BOOL);
-        EXPECT_EQ(eval, false);
+        EXPECT_EQ(eval.type(), Value::Type::NULLVALUE);
     }
     {
         TypeCastingExpression typeCast(Value::Type::STRING, new ConstantExpression(true));

--- a/src/common/function/FunctionManager.cpp
+++ b/src/common/function/FunctionManager.cpp
@@ -146,6 +146,24 @@ std::unordered_map<std::string, std::vector<TypeSignature>> FunctionManager::typ
                   TypeSignature({Value::Type::TIME}, Value::Type::STRING),
                   TypeSignature({Value::Type::DATETIME}, Value::Type::STRING)
                 }},
+    {"toBoolean", {TypeSignature({Value::Type::STRING}, Value::Type::BOOL),
+                   TypeSignature({Value::Type::STRING}, Value::Type::NULLVALUE),
+                   TypeSignature({Value::Type::BOOL}, Value::Type::BOOL)
+                }},
+    {"toFloat", {TypeSignature({Value::Type::STRING}, Value::Type::FLOAT),
+                 TypeSignature({Value::Type::STRING}, Value::Type::NULLVALUE),
+                 TypeSignature({Value::Type::FLOAT}, Value::Type::FLOAT),
+                 TypeSignature({Value::Type::INT}, Value::Type::FLOAT)
+                }},
+    {"toInteger", {TypeSignature({Value::Type::STRING}, Value::Type::INT),
+                   TypeSignature({Value::Type::STRING}, Value::Type::NULLVALUE),
+                   TypeSignature({Value::Type::FLOAT}, Value::Type::INT),
+                   TypeSignature({Value::Type::INT}, Value::Type::INT)
+                }},
+    {"toBoolean", {TypeSignature({Value::Type::STRING}, Value::Type::BOOL),
+                   TypeSignature({Value::Type::STRING}, Value::Type::NULLVALUE),
+                   TypeSignature({Value::Type::BOOL}, Value::Type::BOOL)
+                }},
     {"hash", {TypeSignature({Value::Type::INT}, Value::Type::INT),
               TypeSignature({Value::Type::FLOAT}, Value::Type::INT),
               TypeSignature({Value::Type::STRING}, Value::Type::INT),
@@ -893,6 +911,33 @@ FunctionManager::FunctionManager() {
                     LOG(ERROR) << "toString has not been implemented for " << args[0].type();
                     return Value::kNullBadType;
             }
+        };
+    }
+    {
+        auto &attr = functions_["toBoolean"];
+        attr.minArity_ = 1;
+        attr.maxArity_ = 1;
+        attr.isPure_ = true;
+        attr.body_ = [](const auto &args) -> Value {
+             return Value(args[0]).toBool();
+        };
+    }
+    {
+        auto &attr = functions_["toFloat"];
+        attr.minArity_ = 1;
+        attr.maxArity_ = 1;
+        attr.isPure_ = true;
+        attr.body_ = [](const auto &args) -> Value {
+             return Value(args[0]).toFloat();
+        };
+    }
+    {
+        auto &attr = functions_["toInteger"];
+        attr.minArity_ = 1;
+        attr.maxArity_ = 1;
+        attr.isPure_ = true;
+        attr.body_ = [](const auto &args) -> Value {
+             return Value(args[0]).toInt();
         };
     }
     {

--- a/src/common/function/test/FunctionManagerTest.cpp
+++ b/src/common/function/test/FunctionManagerTest.cpp
@@ -24,7 +24,7 @@ public:
     void TearDown() override {}
 
 protected:
-    void testFunction(const char *expr, std::vector<Value> &args, Value expect) {
+    void testFunction(const char *expr, const std::vector<Value> &args, Value expect) {
         auto result = FunctionManager::get(expr, args.size());
         ASSERT_TRUE(result.ok());
         auto res = result.value()(args);
@@ -171,6 +171,30 @@ TEST_F(FunctionManagerTest, functionCall) {
         TEST_FUNCTION(toString, args_["date"], "1984-10-11");
         TEST_FUNCTION(toString, args_["datetime"], "1984-10-11T12:31:14.341");
         TEST_FUNCTION(toString, args_["nullvalue"], "NULL");
+    }
+    {
+        TEST_FUNCTION(toBoolean, args_["int"], Value::kNullBadType);
+        TEST_FUNCTION(toBoolean, args_["float"], Value::kNullBadType);
+        TEST_FUNCTION(toBoolean, {true}, true);
+        TEST_FUNCTION(toBoolean, {false}, false);
+        TEST_FUNCTION(toBoolean, {"fAlse"}, false);
+        TEST_FUNCTION(toBoolean, {"false "}, Value::kNullValue);
+    }
+    {
+        TEST_FUNCTION(toFloat, args_["int"], 4.0);
+        TEST_FUNCTION(toFloat, args_["float"], 1.1);
+        TEST_FUNCTION(toFloat, {true}, Value::kNullBadType);
+        TEST_FUNCTION(toFloat, {false}, Value::kNullBadType);
+        TEST_FUNCTION(toFloat, {"3.14"}, 3.14);
+        TEST_FUNCTION(toFloat, {"false "}, Value::kNullValue);
+    }
+    {
+        TEST_FUNCTION(toInteger, args_["int"], 4);
+        TEST_FUNCTION(toInteger, args_["float"], 1);
+        TEST_FUNCTION(toInteger, {true}, Value::kNullBadType);
+        TEST_FUNCTION(toInteger, {false}, Value::kNullBadType);
+        TEST_FUNCTION(toInteger, {"1"}, 1);
+        TEST_FUNCTION(toInteger, {"false "}, Value::kNullValue);
     }
     {
         auto result = FunctionManager::get("rand32", args_["rand"].size());
@@ -975,6 +999,46 @@ TEST_F(FunctionManagerTest, returnType) {
         auto result = FunctionManager::getReturnType("toString", {Value::Type::DATE});
         ASSERT_TRUE(result.ok());
         EXPECT_EQ(result.value(), Value::Type::STRING);
+    }
+    {
+        auto result = FunctionManager::getReturnType("toBoolean", {Value::Type::BOOL});
+        ASSERT_TRUE(result.ok());
+        EXPECT_EQ(result.value(), Value::Type::BOOL);
+    }
+    {
+        auto result = FunctionManager::getReturnType("toBoolean", {Value::Type::STRING});
+        ASSERT_TRUE(result.ok());
+        EXPECT_EQ(result.value(), Value::Type::BOOL);
+    }
+    {
+        auto result = FunctionManager::getReturnType("toFloat", {Value::Type::INT});
+        ASSERT_TRUE(result.ok());
+        EXPECT_EQ(result.value(), Value::Type::FLOAT);
+    }
+    {
+        auto result = FunctionManager::getReturnType("toFloat", {Value::Type::FLOAT});
+        ASSERT_TRUE(result.ok());
+        EXPECT_EQ(result.value(), Value::Type::FLOAT);
+    }
+    {
+        auto result = FunctionManager::getReturnType("toFloat", {Value::Type::STRING});
+        ASSERT_TRUE(result.ok());
+        EXPECT_EQ(result.value(), Value::Type::FLOAT);
+    }
+    {
+        auto result = FunctionManager::getReturnType("toInteger", {Value::Type::INT});
+        ASSERT_TRUE(result.ok());
+        EXPECT_EQ(result.value(), Value::Type::INT);
+    }
+    {
+        auto result = FunctionManager::getReturnType("toInteger", {Value::Type::FLOAT});
+        ASSERT_TRUE(result.ok());
+        EXPECT_EQ(result.value(), Value::Type::INT);
+    }
+    {
+        auto result = FunctionManager::getReturnType("toInteger", {Value::Type::STRING});
+        ASSERT_TRUE(result.ok());
+        EXPECT_EQ(result.value(), Value::Type::INT);
     }
     {
         auto result = FunctionManager::getReturnType("strcasecmp",


### PR DESCRIPTION
This PR fixes TypeCastExpression behavior(refer to: [openCypher scalar functions](https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-toboolean )) and add functions related with type conversion.

Depended by [https://github.com/vesoft-inc/nebula-graph/pull/746](https://github.com/vesoft-inc/nebula-graph/pull/746) and [https://github.com/vesoft-inc/nebula-storage/pull/352](https://github.com/vesoft-inc/nebula-storage/pull/352)

Fixes [https://github.com/vesoft-inc/nebula-graph/issues/677](https://github.com/vesoft-inc/nebula-graph/issues/677) and [https://github.com/vesoft-inc/nebula-graph/issues/706](https://github.com/vesoft-inc/nebula-graph/issues/706)

---

Note:
```
Value::toBool() 行为有如下变动:
 - 除 null/bool/string 之外的类型视为非法类型，返回 kNullBadType
 - bool 类型原样返回
 - 字符串 "true"/"FaLse" 等会返回转换后的 bool 值
 - null 和其他字符串会返回 null
 - empty 类型行为暂未定义，目前返回 null
```