### PR TITLE
Make flags/stats/status HTTP API confirm to RESTful specification

### DIFF
--- a/cmake/nebula/ConfigNebulaCommon.cmake
+++ b/cmake/nebula/ConfigNebulaCommon.cmake
@@ -28,7 +28,7 @@ macro(config_nebula_common)
                 -DNEBULA_THIRDPARTY_ROOT=${NEBULA_THIRDPARTY_ROOT}
                 -DNEBULA_OTHER_ROOT=${NEBULA_OTHER_ROOT}
                 -DENABLE_JEMALLOC=${ENABLE_JEMALLOC}
-                -DENABLE_TESTING=ON
+                -DENABLE_TESTING=OFF
                 -DENABLE_CCACHE=${ENABLE_CCACHE}
                 -DENABLE_ASAN=${ENABLE_ASAN}
                 -DENABLE_UBSAN=${ENABLE_UBSAN}

--- a/cmake/nebula/ConfigNebulaCommon.cmake
+++ b/cmake/nebula/ConfigNebulaCommon.cmake
@@ -28,7 +28,7 @@ macro(config_nebula_common)
                 -DNEBULA_THIRDPARTY_ROOT=${NEBULA_THIRDPARTY_ROOT}
                 -DNEBULA_OTHER_ROOT=${NEBULA_OTHER_ROOT}
                 -DENABLE_JEMALLOC=${ENABLE_JEMALLOC}
-                -DENABLE_TESTING=OFF
+                -DENABLE_TESTING=ON
                 -DENABLE_CCACHE=${ENABLE_CCACHE}
                 -DENABLE_ASAN=${ENABLE_ASAN}
                 -DENABLE_UBSAN=${ENABLE_UBSAN}

--- a/src/common/http/HttpClient.cpp
+++ b/src/common/http/HttpClient.cpp
@@ -47,6 +47,28 @@ StatusOr<std::string> HttpClient::post(const std::string& path, const folly::dyn
     return sendRequest(path, data, "POST");
 }
 
+StatusOr<std::string> HttpClient::put(const std::string& path,
+                                       const std::unordered_map<std::string, std::string>& header) {
+    folly::dynamic mapData = folly::dynamic::object;
+    // Build a dynamic object from map
+    for (auto const& it : header) {
+        mapData[it.first] = it.second;
+    }
+    return put(path, mapData);
+}
+
+StatusOr<std::string> HttpClient::put(const std::string& path, const std::string& header) {
+    auto command =
+        folly::stringPrintf("/usr/bin/curl -X PUT %s \"%s\"", header.c_str(), path.c_str());
+    LOG(INFO) << "HTTP PUT Command: " << command;
+    auto result = nebula::ProcessUtils::runCommand(command.c_str());
+    if (result.ok()) {
+        return result.value();
+    } else {
+        return Status::Error(folly::stringPrintf("Http Put Failed: %s", path.c_str()));
+    }
+}
+
 StatusOr<std::string> HttpClient::put(const std::string& path, const folly::dynamic& data) {
     return sendRequest(path, data, "PUT");
 }

--- a/src/common/http/HttpClient.cpp
+++ b/src/common/http/HttpClient.cpp
@@ -22,10 +22,9 @@ StatusOr<std::string> HttpClient::get(const std::string& path, const std::string
 }
 
 StatusOr<std::string> HttpClient::post(const std::string& path, const std::string& header) {
-    auto command = folly::stringPrintf("/usr/bin/curl -X POST %s \"%s\"",
-                                       header.c_str(),
-                                       path.c_str());
-    LOG(INFO) << "HTTP Post Command: " << command;
+    auto command =
+        folly::stringPrintf("/usr/bin/curl -X POST %s \"%s\"", header.c_str(), path.c_str());
+    LOG(INFO) << "HTTP POST Command: " << command;
     auto result = nebula::ProcessUtils::runCommand(command.c_str());
     if (result.ok()) {
         return result.value();
@@ -33,6 +32,57 @@ StatusOr<std::string> HttpClient::post(const std::string& path, const std::strin
         return Status::Error(folly::stringPrintf("Http Post Failed: %s", path.c_str()));
     }
 }
+
+StatusOr<std::string> HttpClient::post(const std::string& path,
+                                       const std::unordered_map<std::string, std::string>& header) {
+    folly::dynamic mapData = folly::dynamic::object;
+    // Build a dynamic object from map
+    for (auto const& it : header) {
+        mapData[it.first] = it.second;
+    }
+    return post(path, mapData);
+}
+
+StatusOr<std::string> HttpClient::post(const std::string& path, const folly::dynamic& data) {
+    return sendRequest(path, data, "POST");
+}
+
+StatusOr<std::string> HttpClient::put(const std::string& path, const folly::dynamic& data) {
+    return sendRequest(path, data, "PUT");
+}
+
+StatusOr<std::string> HttpClient::sendRequest(const std::string& path,
+                                              const folly::dynamic& data,
+                                              const std::string& reqType) {
+    std::string command;
+    if (data.empty()) {
+        command = folly::stringPrintf("curl -X %s -s \"%s\"", reqType.c_str(), path.c_str());
+    } else {
+        command =
+            folly::stringPrintf("curl -X %s -H \"Content-Type: application/json\" -d'%s' -s \"%s\"",
+                                reqType.c_str(),
+                                folly::toJson(data).c_str(),
+                                path.c_str());
+    }
+    LOG(INFO) << folly::stringPrintf("HTTP %s Command: %s", reqType.c_str(), command.c_str());
+    auto result = nebula::ProcessUtils::runCommand(command.c_str());
+    if (result.ok()) {
+        return result.value();
+    } else {
+        return Status::Error(
+            folly::stringPrintf("Http %s Failed: %s", reqType.c_str(), path.c_str()));
+    }
+}
+
+// std::string HttpClient::buildHeaderStr(const std::unordered_map<std::string, std::string>&
+// header) {
+//     std::string headerStr;
+//     for (auto const& it : header) {
+//         auto strSeg = folly::stringPrintf("-H \"%s: %s\" ", it.first.c_str(), it.second.c_str());
+//         headerStr += strSeg;
+//     }
+//     return headerStr;
+// }
 
 }   // namespace http
 }   // namespace nebula

--- a/src/common/http/HttpClient.cpp
+++ b/src/common/http/HttpClient.cpp
@@ -74,15 +74,5 @@ StatusOr<std::string> HttpClient::sendRequest(const std::string& path,
     }
 }
 
-// std::string HttpClient::buildHeaderStr(const std::unordered_map<std::string, std::string>&
-// header) {
-//     std::string headerStr;
-//     for (auto const& it : header) {
-//         auto strSeg = folly::stringPrintf("-H \"%s: %s\" ", it.first.c_str(), it.second.c_str());
-//         headerStr += strSeg;
-//     }
-//     return headerStr;
-// }
-
 }   // namespace http
 }   // namespace nebula

--- a/src/common/http/HttpClient.h
+++ b/src/common/http/HttpClient.h
@@ -18,10 +18,28 @@ public:
     HttpClient() = delete;
 
     ~HttpClient() = default;
-
+    // Send a http GET request
     static StatusOr<std::string> get(const std::string& path, const std::string& options = "-G");
 
+    // Send a http POST request
     static StatusOr<std::string> post(const std::string& path, const std::string& header);
+    // Send a http POST request with a different function signature
+    static StatusOr<std::string> post(const std::string& path,
+                                      const std::unordered_map<std::string, std::string>& header);
+    static StatusOr<std::string> post(const std::string& path,
+                                      const folly::dynamic& data = folly::dynamic::object());
+
+    // Send a http PUT request
+    static StatusOr<std::string> put(const std::string& path,
+                                     const folly::dynamic& data = folly::dynamic::object());
+
+    // static std::string buildHeaderStr(const std::unordered_map<std::string, std::string>&
+    // header);
+
+protected:
+    static StatusOr<std::string> sendRequest(const std::string& path,
+                                             const folly::dynamic& data,
+                                             const std::string& reqType);
 };
 
 }   // namespace http

--- a/src/common/http/HttpClient.h
+++ b/src/common/http/HttpClient.h
@@ -33,9 +33,6 @@ public:
     static StatusOr<std::string> put(const std::string& path,
                                      const folly::dynamic& data = folly::dynamic::object());
 
-    // static std::string buildHeaderStr(const std::unordered_map<std::string, std::string>&
-    // header);
-
 protected:
     static StatusOr<std::string> sendRequest(const std::string& path,
                                              const folly::dynamic& data,

--- a/src/common/http/HttpClient.h
+++ b/src/common/http/HttpClient.h
@@ -30,8 +30,11 @@ public:
                                       const folly::dynamic& data = folly::dynamic::object());
 
     // Send a http PUT request
+    static StatusOr<std::string> put(const std::string& path, const std::string& header);
     static StatusOr<std::string> put(const std::string& path,
-                                     const folly::dynamic& data = folly::dynamic::object());
+                                      const std::unordered_map<std::string, std::string>& header);
+    static StatusOr<std::string> put(const std::string& path,
+                                      const folly::dynamic& data = folly::dynamic::object());
 
 protected:
     static StatusOr<std::string> sendRequest(const std::string& path,

--- a/src/common/stats/StatsManager.cpp
+++ b/src/common/stats/StatsManager.cpp
@@ -262,9 +262,9 @@ StatusOr<StatsManager::VT> StatsManager::readValue(folly::StringPiece metricName
 void StatsManager::readAllValue(folly::dynamic& vals) {
     auto& sm = get();
 
-    for (auto &statsName : sm.nameMap_) {
+    for (auto const& statsName : sm.nameMap_) {
         // Add stats
-        for (auto& method : statsName.second.methods_) {
+        for (auto const& method : statsName.second.methods_) {
             std::string metricPrefix = statsName.first;
             switch (method) {
                 case StatsMethod::SUM:

--- a/src/common/webservice/GetFlagsHandler.cpp
+++ b/src/common/webservice/GetFlagsHandler.cpp
@@ -35,9 +35,9 @@ void GetFlagsHandler::onRequest(std::unique_ptr<HTTPMessage> headers) noexcept {
         returnJson_ = (headers->getQueryParam("return") == "true");
     }
 
-    auto* flagsStr = headers->getQueryParamPtr("names");
-    if (flagsStr != nullptr) {
-        folly::split(",", *flagsStr, flagnames_, true);
+    if (headers->hasQueryParam("names")) {
+        const std::string& names = headers->getQueryParam("names");
+        folly::split(",", names, flagnames_, true);
     }
 }
 
@@ -169,7 +169,8 @@ folly::dynamic GetFlagsHandler::getFlags() {
     return flags;
 }
 
-static std::string valToString(const folly::dynamic& val) {
+// static
+std::string GetFlagsHandler::valToString(const folly::dynamic& val) {
     if (val.isNull()) {
         return "nullptr";
     }

--- a/src/common/webservice/GetFlagsHandler.cpp
+++ b/src/common/webservice/GetFlagsHandler.cpp
@@ -32,7 +32,7 @@ void GetFlagsHandler::onRequest(std::unique_ptr<HTTPMessage> headers) noexcept {
     }
 
     if (headers->hasQueryParam("return")) {
-        returnJson_ = (headers->getQueryParam("return") == "true");
+        returnJson_ = (headers->getQueryParam("return") == "json");
     }
 
     if (headers->hasQueryParam("names")) {

--- a/src/common/webservice/GetFlagsHandler.cpp
+++ b/src/common/webservice/GetFlagsHandler.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018 vesoft inc. All rights reserved.
+/* Copyright (c) 2021 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
@@ -27,15 +27,15 @@ void GetFlagsHandler::onRequest(std::unique_ptr<HTTPMessage> headers) noexcept {
         return;
     }
 
-    if (headers->getQueryParamPtr("verbose") != nullptr) {
-        verbose_ = true;
+    if (headers->hasQueryParam("verbose")) {
+        verbose_ = (headers->getQueryParam("verbose") == "true");
     }
 
-    if (headers->getQueryParamPtr("returnjson") != nullptr) {
-        returnJson_ = true;
+    if (headers->hasQueryParam("return")) {
+        returnJson_ = (headers->getQueryParam("return") == "true");
     }
 
-    auto* flagsStr = headers->getQueryParamPtr("flags");
+    auto* flagsStr = headers->getQueryParamPtr("names");
     if (flagsStr != nullptr) {
         folly::split(",", *flagsStr, flagnames_, true);
     }
@@ -61,10 +61,11 @@ void GetFlagsHandler::onEOM() noexcept {
 
     folly::dynamic vals = getFlags();
     if (returnJson_) {
+        folly::dynamic res = folly::dynamic::object("flags", vals);
         ResponseBuilder(downstream_)
             .status(WebServiceUtils::to(HttpStatusCode::OK),
                     WebServiceUtils::toString(HttpStatusCode::OK))
-            .body(folly::toJson(vals))
+            .body(folly::toPrettyJson(res))
             .sendWithEOM();
     } else {
         ResponseBuilder(downstream_)
@@ -168,36 +169,27 @@ folly::dynamic GetFlagsHandler::getFlags() {
     return flags;
 }
 
+static std::string valToString(const folly::dynamic& val) {
+    if (val.isNull()) {
+        return "nullptr";
+    }
+    if (!val.isString()) {
+        return val.asString();
+    }
+    return "\"" + val.asString() + "\"";
+}
 
-std::string GetFlagsHandler::toStr(folly::dynamic& vals) {
+std::string GetFlagsHandler::toStr(const folly::dynamic& vals) {
     std::stringstream ss;
     for (auto& fi : vals) {
         if (verbose_) {
-            bool isString = fi["type"].asString() == "string";
-            ss << "--" << fi["name"].asString() << ": "
-               << fi["description"].asString() << "\n";
-            ss << "  file: " << fi["file"].asString()
-               << ", type: " << fi["type"].asString()
-               << ", default: "
-               << (isString ? "\"" : "")
-               << fi["default"].asString()
-               << (isString ? "\"" : "")
-               << ", current: "
-               << (isString ? "\"" : "")
-               << fi["value"].asString()
-               << (isString ? "\"" : "")
-               << (fi["is_default"].asBool() ? "(default)" : "")
-               << "\n";
+            ss << "--" << fi["name"].asString() << ": " << fi["description"].asString() << "\n";
+            ss << "  file: " << fi["file"].asString() << ", type: " << fi["type"].asString()
+               << ", default: " << valToString(fi["default"])
+               << ", current: " << valToString(fi["value"])
+               << (fi["is_default"].asBool() ? "(default)" : "") << "\n";
         } else {
-            auto& val = fi["value"];
-            if (val != nullptr) {
-                ss << fi["name"].asString() << "="
-                   << (val.isString() ? "\"" : "")
-                   << val.asString()
-                   << (val.isString() ? "\"\n" : "\n");
-            } else {
-                ss << fi["name"].asString() << "=nullptr\n";
-            }
+            ss << fi["name"].asString() << "=" << valToString(fi["value"]) << "\n";
         }
     }
     return ss.str();

--- a/src/common/webservice/GetFlagsHandler.cpp
+++ b/src/common/webservice/GetFlagsHandler.cpp
@@ -31,13 +31,13 @@ void GetFlagsHandler::onRequest(std::unique_ptr<HTTPMessage> headers) noexcept {
         verbose_ = (headers->getQueryParam("verbose") == "true");
     }
 
-    if (headers->hasQueryParam("return")) {
-        returnJson_ = (headers->getQueryParam("return") == "json");
+    if (headers->hasQueryParam("format")) {
+        returnJson_ = (headers->getQueryParam("format") == "json");
     }
 
-    if (headers->hasQueryParam("names")) {
-        const std::string& names = headers->getQueryParam("names");
-        folly::split(",", names, flagnames_, true);
+    if (headers->hasQueryParam("flags")) {
+        const std::string& flags = headers->getQueryParam("flags");
+        folly::split(",", flags, flagnames_, true);
     }
 }
 

--- a/src/common/webservice/GetFlagsHandler.h
+++ b/src/common/webservice/GetFlagsHandler.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018 vesoft inc. All rights reserved.
+/* Copyright (c) 2021 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
@@ -36,7 +36,7 @@ private:
     void addOneFlag(folly::dynamic& vals,
                     const std::string& flagname,
                     const gflags::CommandLineFlagInfo* info);
-    std::string toStr(folly::dynamic& vals);
+    std::string toStr(const folly::dynamic& vals);
 
 private:
     HttpCode err_{HttpCode::SUCCEEDED};

--- a/src/common/webservice/GetFlagsHandler.h
+++ b/src/common/webservice/GetFlagsHandler.h
@@ -38,6 +38,8 @@ private:
                     const gflags::CommandLineFlagInfo* info);
     std::string toStr(const folly::dynamic& vals);
 
+    static std::string valToString(const folly::dynamic& val);
+
 private:
     HttpCode err_{HttpCode::SUCCEEDED};
     bool verbose_{false};

--- a/src/common/webservice/GetStatsHandler.h
+++ b/src/common/webservice/GetStatsHandler.h
@@ -33,11 +33,6 @@ public:
 
 protected:
     virtual folly::dynamic getStats() const;
-    void addOneStat(folly::dynamic& vals, const std::string& statName,
-                    int64_t statValue) const;
-    void addOneStat(folly::dynamic& vals,
-                    const std::string& statName,
-                    const std::string& error) const;
     std::string toStr(folly::dynamic& vals) const;
 
 protected:

--- a/src/common/webservice/GetStatsHandler.h
+++ b/src/common/webservice/GetStatsHandler.h
@@ -33,6 +33,10 @@ public:
 
 protected:
     virtual folly::dynamic getStats() const;
+    void addOneStat(folly::dynamic& vals, const std::string& statName, int64_t statValue) const;
+    void addOneStat(folly::dynamic& vals,
+                    const std::string& statName,
+                    const std::string& error) const;
     std::string toStr(folly::dynamic& vals) const;
 
 protected:

--- a/src/common/webservice/SetFlagsHandler.cpp
+++ b/src/common/webservice/SetFlagsHandler.cpp
@@ -20,40 +20,35 @@ using proxygen::UpgradeProtocol;
 using proxygen::ResponseBuilder;
 
 void SetFlagsHandler::onRequest(std::unique_ptr<HTTPMessage> headers) noexcept {
-    if (headers->getMethod().value() != HTTPMethod::GET) {
+    if (headers->getMethod().value() != HTTPMethod::PUT) {
         // Unsupported method
         err_ = HttpCode::E_UNSUPPORTED_METHOD;
         return;
     }
-
-    VLOG(1) << "SetFlagsHandler got query string \"" << headers->getQueryString();
-
-    if (headers->hasQueryParam("flag")) {
-        name_ = headers->getDecodedQueryParam("flag");
-    } else {
-        LOG(ERROR) << "There is no flag specified when setting the flag value";
-        err_ = HttpCode::E_UNPROCESSABLE;
-    }
-
-    if (headers->hasQueryParam("value")) {
-        value_ = headers->getDecodedQueryParam("value");
-    } else {
-        LOG(ERROR) << "There is no value specified when setting the flag value";
-        err_ = HttpCode::E_UNPROCESSABLE;
-    }
-
-    if (err_ == HttpCode::SUCCEEDED) {
-        VLOG(1) << "Set flag " << name_ << " = " << value_;
-    }
 }
 
 
-void SetFlagsHandler::onBody(std::unique_ptr<folly::IOBuf>) noexcept {
-    // Do nothing, we only support GET
+void SetFlagsHandler::onBody(std::unique_ptr<folly::IOBuf> body) noexcept {
+    if (body_) {
+        body_->appendChain(std::move(body));
+    } else {
+        body_ = std::move(body);
+    }
 }
 
 
 void SetFlagsHandler::onEOM() noexcept {
+    folly::dynamic flags;
+    try {
+        std::string body = body_->moveToFbString().toStdString();
+        flags = folly::parseJson(body);
+        if (flags.empty()) {
+            err_ = HttpCode::E_UNPROCESSABLE;
+        }
+    } catch (const std::exception &e) {
+        LOG(ERROR) << "Fail to update flags: " << e.what();
+        err_ = HttpCode::E_UNPROCESSABLE;
+    }
     switch (err_) {
         case HttpCode::E_UNSUPPORTED_METHOD:
             ResponseBuilder(downstream_)
@@ -71,20 +66,23 @@ void SetFlagsHandler::onEOM() noexcept {
             break;
     }
 
-    if (gflags::SetCommandLineOption(name_.c_str(), value_.c_str()).empty()) {
-        // Failed
-        ResponseBuilder(downstream_)
-            .status(WebServiceUtils::to(HttpStatusCode::OK),
-                    WebServiceUtils::toString(HttpStatusCode::OK))
-            .body("false")
-            .sendWithEOM();
-    } else {
-        ResponseBuilder(downstream_)
-            .status(WebServiceUtils::to(HttpStatusCode::OK),
-                    WebServiceUtils::toString(HttpStatusCode::OK))
-            .body("true")
-            .sendWithEOM();
+    folly::dynamic failedOptions = folly::dynamic::array();
+    for (auto &item : flags.items()) {
+        const std::string &name = item.first.asString();
+        const std::string &value = item.second.asString();
+        const std::string &newValue = gflags::SetCommandLineOption(name.c_str(), value.c_str());
+        if (newValue.empty()) {
+            failedOptions.push_back(name);
+        }
     }
+    folly::dynamic body = failedOptions.empty()
+                              ? folly::dynamic::object("errCode", 0)
+                              : folly::dynamic::object("failedOptions", failedOptions);
+    ResponseBuilder(downstream_)
+        .status(WebServiceUtils::to(HttpStatusCode::OK),
+                WebServiceUtils::toString(HttpStatusCode::OK))
+        .body(folly::toPrettyJson(body))
+        .sendWithEOM();
 }
 
 

--- a/src/common/webservice/SetFlagsHandler.h
+++ b/src/common/webservice/SetFlagsHandler.h
@@ -32,8 +32,7 @@ public:
 
 private:
     HttpCode err_{HttpCode::SUCCEEDED};
-    std::string name_;
-    std::string value_;
+    std::unique_ptr<folly::IOBuf> body_;
 };
 
 }  // namespace nebula

--- a/src/common/webservice/WebService.cpp
+++ b/src/common/webservice/WebService.cpp
@@ -67,27 +67,15 @@ Status WebService::start() {
         return Status::OK();
     }
 
-    router().get("/get_flag").handler([](web::PathParams&& params) {
+    router().get("/flags").handler([](web::PathParams&& params) {
         DCHECK(params.empty());
         return new GetFlagsHandler();
     });
-    router().get("/get_flags").handler([](web::PathParams&& params) {
-        DCHECK(params.empty());
-        return new GetFlagsHandler();
-    });
-    router().get("/set_flag").handler([](web::PathParams&& params) {
+    router().put("/flags").handler([](web::PathParams&& params) {
         DCHECK(params.empty());
         return new SetFlagsHandler();
     });
-    router().get("/set_flags").handler([](web::PathParams&& params) {
-        DCHECK(params.empty());
-        return new SetFlagsHandler();
-    });
-    router().get("/get_stat").handler([](web::PathParams&& params) {
-        DCHECK(params.empty());
-        return new GetStatsHandler();
-    });
-    router().get("/get_stats").handler([](web::PathParams&& params) {
+    router().get("/stats").handler([](web::PathParams&& params) {
         DCHECK(params.empty());
         return new GetStatsHandler();
     });

--- a/src/common/webservice/test/FlagsAccessTest.cpp
+++ b/src/common/webservice/test/FlagsAccessTest.cpp
@@ -39,30 +39,6 @@ private:
     std::unique_ptr<WebService> webSvc_;
 };
 
-// TEST(FlagsAccessTest, GetSetTest) {
-//     std::string resp;
-//     ASSERT_TRUE(getUrl("/flags?names=int32_test", resp));
-//     EXPECT_EQ(folly::stringPrintf("int32_test=%d\n", FLAGS_int32_test), resp);
-
-//     ASSERT_TRUE(getUrl("/flags?names=int64_test,bool_test,string_test", resp));
-//     EXPECT_EQ(folly::stringPrintf("int64_test=%ld\nbool_test=%s\nstring_test=\"%s\"\n",
-//                                   FLAGS_int64_test,
-//                                   (FLAGS_bool_test ? "1" : "0"),
-//                                   FLAGS_string_test.c_str()),
-//               resp);
-
-//     folly::dynamic data = folly::dynamic::object("int64_test", 20);
-//     auto status = putUrl("/flags", data);
-//     ASSERT_TRUE(status.ok());
-//     folly::dynamic json = folly::parseJson(status.value());
-//     ASSERT_EQ(0, json["errCode"].asInt());
-//     ASSERT_TRUE(getUrl("/flags?names=int64_test", resp));
-//     EXPECT_EQ(std::string("int64_test=20\n"), resp);
-
-//     ASSERT_TRUE(getUrl("/flags", resp));
-//     ASSERT_TRUE(resp.find("crash_test=nullptr") != std::string::npos);
-// }
-
 TEST(FlagsAccessTest, GetSetTest) {
     std::string resp;
     ASSERT_TRUE(getUrl("/flags?names=int32_test", resp));

--- a/src/common/webservice/test/FlagsAccessTest.cpp
+++ b/src/common/webservice/test/FlagsAccessTest.cpp
@@ -41,10 +41,10 @@ private:
 
 TEST(FlagsAccessTest, GetSetTest) {
     std::string resp;
-    ASSERT_TRUE(getUrl("/flags?names=int32_test", resp));
+    ASSERT_TRUE(getUrl("/flags?flags=int32_test", resp));
     EXPECT_EQ(folly::stringPrintf("int32_test=%d\n", FLAGS_int32_test), resp);
 
-    ASSERT_TRUE(getUrl("/flags?names=int64_test,bool_test,string_test", resp));
+    ASSERT_TRUE(getUrl("/flags?flags=int64_test,bool_test,string_test", resp));
     EXPECT_EQ(folly::stringPrintf("int64_test=%ld\nbool_test=%s\nstring_test=\"%s\"\n",
                                   FLAGS_int64_test,
                                   (FLAGS_bool_test ? "1" : "0"),
@@ -56,7 +56,7 @@ TEST(FlagsAccessTest, GetSetTest) {
     ASSERT_TRUE(status.ok());
     folly::dynamic json = folly::parseJson(status.value());
     ASSERT_EQ(0, json["errCode"].asInt());
-    ASSERT_TRUE(getUrl("/flags?names=int64_test", resp));
+    ASSERT_TRUE(getUrl("/flags?flags=int64_test", resp));
     EXPECT_EQ(std::string("int64_test=20\n"), resp);
 
     ASSERT_TRUE(getUrl("/flags", resp));
@@ -75,7 +75,7 @@ TEST(FlagsAccessTest, TestSetFlagsFailure) {
 
 TEST(FlagsAccessTest, JsonTest) {
     std::string resp;
-    ASSERT_TRUE(getUrl("/flags?names=double_test&return=json", resp));
+    ASSERT_TRUE(getUrl("/flags?flags=double_test&format=json", resp));
     auto json = folly::parseJson(resp)["flags"];
     ASSERT_TRUE(json.isArray());
     ASSERT_EQ(1UL, json.size());
@@ -95,7 +95,7 @@ TEST(FlagsAccessTest, JsonTest) {
 
 TEST(FlagsAccessTest, VerboseTest) {
     std::string resp;
-    ASSERT_TRUE(getUrl("/flags?names=int32_test&return=json&verbose=true", resp));
+    ASSERT_TRUE(getUrl("/flags?flags=int32_test&format=json&verbose=true", resp));
     auto json = folly::parseJson(resp)["flags"];
     ASSERT_TRUE(json.isArray());
     ASSERT_EQ(1UL, json.size());

--- a/src/common/webservice/test/FlagsAccessTest.cpp
+++ b/src/common/webservice/test/FlagsAccessTest.cpp
@@ -39,82 +39,98 @@ private:
     std::unique_ptr<WebService> webSvc_;
 };
 
+// TEST(FlagsAccessTest, GetSetTest) {
+//     std::string resp;
+//     ASSERT_TRUE(getUrl("/flags?names=int32_test", resp));
+//     EXPECT_EQ(folly::stringPrintf("int32_test=%d\n", FLAGS_int32_test), resp);
+
+//     ASSERT_TRUE(getUrl("/flags?names=int64_test,bool_test,string_test", resp));
+//     EXPECT_EQ(folly::stringPrintf("int64_test=%ld\nbool_test=%s\nstring_test=\"%s\"\n",
+//                                   FLAGS_int64_test,
+//                                   (FLAGS_bool_test ? "1" : "0"),
+//                                   FLAGS_string_test.c_str()),
+//               resp);
+
+//     folly::dynamic data = folly::dynamic::object("int64_test", 20);
+//     auto status = putUrl("/flags", data);
+//     ASSERT_TRUE(status.ok());
+//     folly::dynamic json = folly::parseJson(status.value());
+//     ASSERT_EQ(0, json["errCode"].asInt());
+//     ASSERT_TRUE(getUrl("/flags?names=int64_test", resp));
+//     EXPECT_EQ(std::string("int64_test=20\n"), resp);
+
+//     ASSERT_TRUE(getUrl("/flags", resp));
+//     ASSERT_TRUE(resp.find("crash_test=nullptr") != std::string::npos);
+// }
+
 TEST(FlagsAccessTest, GetSetTest) {
     std::string resp;
-    ASSERT_TRUE(getUrl("/get_flags?flags=int32_test", resp));
+    ASSERT_TRUE(getUrl("/flags?names=int32_test", resp));
     EXPECT_EQ(folly::stringPrintf("int32_test=%d\n", FLAGS_int32_test), resp);
 
-    ASSERT_TRUE(getUrl("/get_flags?flags=int64_test,bool_test,string_test", resp));
+    ASSERT_TRUE(getUrl("/flags?names=int64_test,bool_test,string_test", resp));
     EXPECT_EQ(folly::stringPrintf("int64_test=%ld\nbool_test=%s\nstring_test=\"%s\"\n",
                                   FLAGS_int64_test,
                                   (FLAGS_bool_test ? "1" : "0"),
                                   FLAGS_string_test.c_str()),
               resp);
-
-    ASSERT_TRUE(getUrl("/set_flag?flag=int64_test&value=20", resp));
-    ASSERT_EQ("true", resp);
-    ASSERT_TRUE(getUrl("/get_flags?flags=int64_test", resp));
-    EXPECT_EQ(std::string("int64_test=20\n"), resp);
-
-    ASSERT_TRUE(getUrl("/get_flags", resp));
-    ASSERT_TRUE(resp.find("crash_test=nullptr") != std::string::npos);
 }
 
-TEST(FlagsAccessTest, JsonTest) {
-    std::string resp;
-    ASSERT_TRUE(getUrl("/get_flags?flags=double_test&returnjson", resp));
-    auto json = folly::parseJson(resp);
-    ASSERT_TRUE(json.isArray());
-    ASSERT_EQ(1UL, json.size());
-    ASSERT_TRUE(json[0].isObject());
-    ASSERT_EQ(2UL, json[0].size());
+// TEST(FlagsAccessTest, JsonTest) {
+//     std::string resp;
+//     ASSERT_TRUE(getUrl("/flags?names=double_test&return=json", resp));
+//     auto json = folly::parseJson(resp)["flags"];
+//     ASSERT_TRUE(json.isArray());
+//     ASSERT_EQ(1UL, json.size());
+//     ASSERT_TRUE(json[0].isObject());
+//     ASSERT_EQ(2UL, json[0].size());
 
-    auto it = json[0].find("name");
-    ASSERT_NE(json[0].items().end(), it);
-    ASSERT_TRUE(it->second.isString());
-    EXPECT_EQ("double_test", it->second.getString());
+//     auto it = json[0].find("name");
+//     ASSERT_NE(json[0].items().end(), it);
+//     ASSERT_TRUE(it->second.isString());
+//     EXPECT_EQ("double_test", it->second.getString());
 
-    it = json[0].find("value");
-    ASSERT_NE(json[0].items().end(), it);
-    ASSERT_TRUE(it->second.isDouble());
-    EXPECT_DOUBLE_EQ(FLAGS_double_test, it->second.getDouble());
-}
+//     it = json[0].find("value");
+//     ASSERT_NE(json[0].items().end(), it);
+//     ASSERT_TRUE(it->second.isDouble());
+//     EXPECT_DOUBLE_EQ(FLAGS_double_test, it->second.getDouble());
+// }
 
 
-TEST(FlagsAccessTest, VerboseTest) {
-    std::string resp;
-    ASSERT_TRUE(getUrl("/get_flags?flags=int32_test&returnjson&verbose", resp));
-    auto json = folly::parseJson(resp);
-    ASSERT_TRUE(json.isArray());
-    ASSERT_EQ(1UL, json.size());
-    ASSERT_TRUE(json[0].isObject());
-    ASSERT_EQ(7UL, json[0].size());
+// TEST(FlagsAccessTest, VerboseTest) {
+//     std::string resp;
+//     ASSERT_TRUE(getUrl("/get_flags?flags=int32_test&returnjson&verbose", resp));
+//     auto json = folly::parseJson(resp);
+//     ASSERT_TRUE(json.isArray());
+//     ASSERT_EQ(1UL, json.size());
+//     ASSERT_TRUE(json[0].isObject());
+//     ASSERT_EQ(7UL, json[0].size());
 
-    auto it = json[0].find("name");
-    ASSERT_NE(json[0].items().end(), it);
-    ASSERT_TRUE(it->second.isString());
-    EXPECT_EQ("int32_test", it->second.getString());
+//     auto it = json[0].find("name");
+//     ASSERT_NE(json[0].items().end(), it);
+//     ASSERT_TRUE(it->second.isString());
+//     EXPECT_EQ("int32_test", it->second.getString());
 
-    it = json[0].find("value");
-    ASSERT_NE(json[0].items().end(), it);
-    ASSERT_TRUE(it->second.isInt());
-    EXPECT_EQ(FLAGS_int32_test, it->second.getInt());
+//     it = json[0].find("value");
+//     ASSERT_NE(json[0].items().end(), it);
+//     ASSERT_TRUE(it->second.isInt());
+//     EXPECT_EQ(FLAGS_int32_test, it->second.getInt());
 
-    it = json[0].find("type");
-    ASSERT_NE(json[0].items().end(), it);
-    ASSERT_TRUE(it->second.isString());
-    EXPECT_EQ("int32", it->second.getString());
+//     it = json[0].find("type");
+//     ASSERT_NE(json[0].items().end(), it);
+//     ASSERT_TRUE(it->second.isString());
+//     EXPECT_EQ("int32", it->second.getString());
 
-    it = json[0].find("file");
-    ASSERT_NE(json[0].items().end(), it);
-    ASSERT_TRUE(it->second.isString());
-    EXPECT_EQ(__FILE__, it->second.getString());
+//     it = json[0].find("file");
+//     ASSERT_NE(json[0].items().end(), it);
+//     ASSERT_TRUE(it->second.isString());
+//     EXPECT_EQ(__FILE__, it->second.getString());
 
-    it = json[0].find("is_default");
-    ASSERT_NE(json[0].items().end(), it);
-    ASSERT_TRUE(it->second.isBool());
-    EXPECT_TRUE(it->second.getBool());
-}
+//     it = json[0].find("is_default");
+//     ASSERT_NE(json[0].items().end(), it);
+//     ASSERT_TRUE(it->second.isBool());
+//     EXPECT_TRUE(it->second.getBool());
+// }
 
 
 TEST(FlagsAccessTest, ErrorTest) {

--- a/src/common/webservice/test/FlagsAccessTest.cpp
+++ b/src/common/webservice/test/FlagsAccessTest.cpp
@@ -76,62 +76,60 @@ TEST(FlagsAccessTest, GetSetTest) {
               resp);
 }
 
-// TEST(FlagsAccessTest, JsonTest) {
-//     std::string resp;
-//     ASSERT_TRUE(getUrl("/flags?names=double_test&return=json", resp));
-//     auto json = folly::parseJson(resp)["flags"];
-//     ASSERT_TRUE(json.isArray());
-//     ASSERT_EQ(1UL, json.size());
-//     ASSERT_TRUE(json[0].isObject());
-//     ASSERT_EQ(2UL, json[0].size());
+TEST(FlagsAccessTest, JsonTest) {
+    std::string resp;
+    ASSERT_TRUE(getUrl("/flags?names=double_test&return=json", resp));
+    auto json = folly::parseJson(resp)["flags"];
+    ASSERT_TRUE(json.isArray());
+    ASSERT_EQ(1UL, json.size());
+    ASSERT_TRUE(json[0].isObject());
+    ASSERT_EQ(2UL, json[0].size());
 
-//     auto it = json[0].find("name");
-//     ASSERT_NE(json[0].items().end(), it);
-//     ASSERT_TRUE(it->second.isString());
-//     EXPECT_EQ("double_test", it->second.getString());
+    auto it = json[0].find("name");
+    ASSERT_NE(json[0].items().end(), it);
+    ASSERT_TRUE(it->second.isString());
+    EXPECT_EQ("double_test", it->second.getString());
 
-//     it = json[0].find("value");
-//     ASSERT_NE(json[0].items().end(), it);
-//     ASSERT_TRUE(it->second.isDouble());
-//     EXPECT_DOUBLE_EQ(FLAGS_double_test, it->second.getDouble());
-// }
+    it = json[0].find("value");
+    ASSERT_NE(json[0].items().end(), it);
+    ASSERT_TRUE(it->second.isDouble());
+    EXPECT_DOUBLE_EQ(FLAGS_double_test, it->second.getDouble());
+}
 
+TEST(FlagsAccessTest, VerboseTest) {
+    std::string resp;
+    ASSERT_TRUE(getUrl("/flags?names=int32_test&return=json&verbose=true", resp));
+    auto json = folly::parseJson(resp)["flags"];
+    ASSERT_TRUE(json.isArray());
+    ASSERT_EQ(1UL, json.size());
+    ASSERT_TRUE(json[0].isObject());
+    ASSERT_EQ(7UL, json[0].size());
 
-// TEST(FlagsAccessTest, VerboseTest) {
-//     std::string resp;
-//     ASSERT_TRUE(getUrl("/get_flags?flags=int32_test&returnjson&verbose", resp));
-//     auto json = folly::parseJson(resp);
-//     ASSERT_TRUE(json.isArray());
-//     ASSERT_EQ(1UL, json.size());
-//     ASSERT_TRUE(json[0].isObject());
-//     ASSERT_EQ(7UL, json[0].size());
+    auto it = json[0].find("name");
+    ASSERT_NE(json[0].items().end(), it);
+    ASSERT_TRUE(it->second.isString());
+    EXPECT_EQ("int32_test", it->second.getString());
 
-//     auto it = json[0].find("name");
-//     ASSERT_NE(json[0].items().end(), it);
-//     ASSERT_TRUE(it->second.isString());
-//     EXPECT_EQ("int32_test", it->second.getString());
+    it = json[0].find("value");
+    ASSERT_NE(json[0].items().end(), it);
+    ASSERT_TRUE(it->second.isInt());
+    EXPECT_EQ(FLAGS_int32_test, it->second.getInt());
 
-//     it = json[0].find("value");
-//     ASSERT_NE(json[0].items().end(), it);
-//     ASSERT_TRUE(it->second.isInt());
-//     EXPECT_EQ(FLAGS_int32_test, it->second.getInt());
+    it = json[0].find("type");
+    ASSERT_NE(json[0].items().end(), it);
+    ASSERT_TRUE(it->second.isString());
+    EXPECT_EQ("int32", it->second.getString());
 
-//     it = json[0].find("type");
-//     ASSERT_NE(json[0].items().end(), it);
-//     ASSERT_TRUE(it->second.isString());
-//     EXPECT_EQ("int32", it->second.getString());
+    it = json[0].find("file");
+    ASSERT_NE(json[0].items().end(), it);
+    ASSERT_TRUE(it->second.isString());
+    EXPECT_EQ(__FILE__, it->second.getString());
 
-//     it = json[0].find("file");
-//     ASSERT_NE(json[0].items().end(), it);
-//     ASSERT_TRUE(it->second.isString());
-//     EXPECT_EQ(__FILE__, it->second.getString());
-
-//     it = json[0].find("is_default");
-//     ASSERT_NE(json[0].items().end(), it);
-//     ASSERT_TRUE(it->second.isBool());
-//     EXPECT_TRUE(it->second.getBool());
-// }
-
+    it = json[0].find("is_default");
+    ASSERT_NE(json[0].items().end(), it);
+    ASSERT_TRUE(it->second.isBool());
+    EXPECT_TRUE(it->second.getBool());
+}
 
 TEST(FlagsAccessTest, ErrorTest) {
     std::string resp;

--- a/src/common/webservice/test/StatsReaderTest.cpp
+++ b/src/common/webservice/test/StatsReaderTest.cpp
@@ -55,21 +55,21 @@ TEST(StatsReaderTest, GetStatsTest) {
         int64_t statSum = StatsManager::readValue("stat01.sum.60").value();
         EXPECT_EQ(5050, statSum);
         std::string resp1;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat01.sum.60", resp1));
+        ASSERT_TRUE(getUrl("/stats?names=stat01.sum.60", resp1));
         EXPECT_EQ(folly::stringPrintf("stat01.sum.60=%ld\n", statSum), resp1);
 
         statSum = 0;
         statSum = StatsManager::readValue("stat01.sum.600").value();
         EXPECT_EQ(5050, statSum);
         std::string resp2;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat01.sum.600", resp2));
+        ASSERT_TRUE(getUrl("/stats?names=stat01.sum.600", resp2));
         EXPECT_EQ(folly::stringPrintf("stat01.sum.600=%ld\n", statSum), resp2);
 
         statSum = 0;
         statSum = StatsManager::readValue("stat01.sum.3600").value();
         EXPECT_EQ(5050, statSum);
         std::string resp3;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat01.sum.3600", resp3));
+        ASSERT_TRUE(getUrl("/stats?names=stat01.sum.3600", resp3));
         EXPECT_EQ(folly::stringPrintf("stat01.sum.3600=%ld\n", statSum), resp3);
     }
 
@@ -77,33 +77,33 @@ TEST(StatsReaderTest, GetStatsTest) {
         int64_t statCount = StatsManager::readValue("stat01.count.60").value();
         EXPECT_EQ(100, statCount);
         std::string resp1;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat01.count.60", resp1));
+        ASSERT_TRUE(getUrl("/stats?names=stat01.count.60", resp1));
         EXPECT_EQ(folly::stringPrintf("stat01.count.60=%ld\n", statCount), resp1);
 
         statCount = 0;
         statCount = StatsManager::readValue("stat01.count.600").value();
         EXPECT_EQ(100, statCount);
         std::string resp2;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat01.count.600", resp2));
+        ASSERT_TRUE(getUrl("/stats?names=stat01.count.600", resp2));
         EXPECT_EQ(folly::stringPrintf("stat01.count.600=%ld\n", statCount), resp2);
 
         statCount = 0;
         statCount = StatsManager::readValue("stat01.count.3600").value();
         EXPECT_EQ(100, statCount);
         std::string resp3;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat01.count.3600", resp3));
+        ASSERT_TRUE(getUrl("/stats?names=stat01.count.3600", resp3));
         EXPECT_EQ(folly::stringPrintf("stat01.count.3600=%ld\n", statCount), resp3);
     }
 
     {
         // get multi stats
         std::string resp;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat01.sum.60,stat01.avg.60,stat01.count.60", resp));
+        ASSERT_TRUE(getUrl("/stats?names=stat01.sum.60,stat01.avg.60,stat01.count.60", resp));
         EXPECT_EQ(std::string("stat01.sum.60=5050\nstat01.avg.60=50\nstat01.count.60=100\n"), resp);
 
         // get multi stats, among invalid stat
         std::string resp1;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat01.sum.60,stat01.avg.60,stat01.count.60,"
+        ASSERT_TRUE(getUrl("/stats?names=stat01.sum.60,stat01.avg.60,stat01.count.60,"
                                             "stat01.p99.60", resp1));
         EXPECT_EQ(std::string("stat01.sum.60=5050\nstat01.avg.60=50\nstat01.count.60=100\n"
                               "stat01.p99.60=Invalid stats\n"), resp1);
@@ -112,28 +112,19 @@ TEST(StatsReaderTest, GetStatsTest) {
     {
         // return json
         std::string resp;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat01.sum.60&returnjson", resp));
+        ASSERT_TRUE(getUrl("/stats?names=stat01.sum.60&return=json", resp));
         auto json = folly::parseJson(resp);
         ASSERT_TRUE(json.isArray());
         ASSERT_EQ(1UL, json.size());
         ASSERT_TRUE(json[0].isObject());
-        ASSERT_EQ(2UL, json[0].size());
-
-        auto it = json[0].find("name");
-        ASSERT_NE(json[0].items().end(), it);
-        ASSERT_TRUE(it->second.isString());
-        EXPECT_EQ("stat01.sum.60", it->second.getString());
-
-        it = json[0].find("value");
-        ASSERT_NE(json[0].items().end(), it);
-        ASSERT_TRUE(it->second.isInt());
-        EXPECT_EQ(5050, it->second.getInt());
+        folly::dynamic expected = folly::dynamic::object("stat01.sum.60", 5050);
+        ASSERT_EQ(expected, json[0]);
     }
 
     {
         // get all stats(sum,count,avg,rate)
         std::string resp;
-        ASSERT_TRUE(getUrl("/get_stats?stats= ", resp));
+        ASSERT_TRUE(getUrl("/stats?names= ", resp));
         EXPECT_FALSE(resp.empty());
     }
 
@@ -165,21 +156,21 @@ TEST(StatsReaderTest, GetHistoTest) {
         int64_t statAvg = StatsManager::readValue("stat02.avg.60").value();
         EXPECT_EQ(50, statAvg);
         std::string resp1;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat02.avg.60", resp1));
+        ASSERT_TRUE(getUrl("/stats?names=stat02.avg.60", resp1));
         EXPECT_EQ(folly::stringPrintf("stat02.avg.60=%ld\n", statAvg), resp1);
 
         statAvg = 0;
         statAvg = StatsManager::readValue("stat02.Avg.600").value();
         EXPECT_EQ(50, statAvg);
         std::string resp2;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat02.Avg.600", resp2));
+        ASSERT_TRUE(getUrl("/stats?names=stat02.Avg.600", resp2));
         EXPECT_EQ(folly::stringPrintf("stat02.Avg.600=%ld\n", statAvg), resp2);
 
         statAvg = 0;
         statAvg = StatsManager::readValue("stat02.AVG.3600").value();
         EXPECT_EQ(50, statAvg);
         std::string resp3;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat02.AVG.3600", resp3));
+        ASSERT_TRUE(getUrl("/stats?names=stat02.AVG.3600", resp3));
         EXPECT_EQ(folly::stringPrintf("stat02.AVG.3600=%ld\n", statAvg), resp3);
     }
 
@@ -187,20 +178,20 @@ TEST(StatsReaderTest, GetHistoTest) {
         int64_t statP = StatsManager::readValue("stat02.p99.60").value();
         EXPECT_EQ(100, statP);
         std::string resp1;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat02.p99.60", resp1));
+        ASSERT_TRUE(getUrl("/stats?names=stat02.p99.60", resp1));
         EXPECT_EQ(folly::stringPrintf("stat02.p99.60=%ld\n", statP), resp1);
 
         statP = 0;
         statP = StatsManager::readValue("stat02.P99.600").value();
         EXPECT_EQ(100, statP);
         std::string resp2;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat02.P99.600", resp2));
+        ASSERT_TRUE(getUrl("/stats?names=stat02.P99.600", resp2));
         EXPECT_EQ(folly::stringPrintf("stat02.P99.600=%ld\n", statP), resp2);
 
         statP = 0;
         EXPECT_FALSE(StatsManager::readValue("stat02.t99.3600").ok());
         std::string resp3;
-        ASSERT_TRUE(getUrl("/get_stats?stats=stat02.t99.3600", resp3));
+        ASSERT_TRUE(getUrl("/stats?names=stat02.t99.3600", resp3));
         EXPECT_EQ("stat02.t99.3600=Unsupported statistic method \"t99\"\n", resp3);
     }
 }

--- a/src/common/webservice/test/StatsReaderTest.cpp
+++ b/src/common/webservice/test/StatsReaderTest.cpp
@@ -55,21 +55,21 @@ TEST(StatsReaderTest, GetStatsTest) {
         int64_t statSum = StatsManager::readValue("stat01.sum.60").value();
         EXPECT_EQ(5050, statSum);
         std::string resp1;
-        ASSERT_TRUE(getUrl("/stats?names=stat01.sum.60", resp1));
+        ASSERT_TRUE(getUrl("/stats?stats=stat01.sum.60", resp1));
         EXPECT_EQ(folly::stringPrintf("stat01.sum.60=%ld\n", statSum), resp1);
 
         statSum = 0;
         statSum = StatsManager::readValue("stat01.sum.600").value();
         EXPECT_EQ(5050, statSum);
         std::string resp2;
-        ASSERT_TRUE(getUrl("/stats?names=stat01.sum.600", resp2));
+        ASSERT_TRUE(getUrl("/stats?stats=stat01.sum.600", resp2));
         EXPECT_EQ(folly::stringPrintf("stat01.sum.600=%ld\n", statSum), resp2);
 
         statSum = 0;
         statSum = StatsManager::readValue("stat01.sum.3600").value();
         EXPECT_EQ(5050, statSum);
         std::string resp3;
-        ASSERT_TRUE(getUrl("/stats?names=stat01.sum.3600", resp3));
+        ASSERT_TRUE(getUrl("/stats?stats=stat01.sum.3600", resp3));
         EXPECT_EQ(folly::stringPrintf("stat01.sum.3600=%ld\n", statSum), resp3);
     }
 
@@ -77,33 +77,33 @@ TEST(StatsReaderTest, GetStatsTest) {
         int64_t statCount = StatsManager::readValue("stat01.count.60").value();
         EXPECT_EQ(100, statCount);
         std::string resp1;
-        ASSERT_TRUE(getUrl("/stats?names=stat01.count.60", resp1));
+        ASSERT_TRUE(getUrl("/stats?stats=stat01.count.60", resp1));
         EXPECT_EQ(folly::stringPrintf("stat01.count.60=%ld\n", statCount), resp1);
 
         statCount = 0;
         statCount = StatsManager::readValue("stat01.count.600").value();
         EXPECT_EQ(100, statCount);
         std::string resp2;
-        ASSERT_TRUE(getUrl("/stats?names=stat01.count.600", resp2));
+        ASSERT_TRUE(getUrl("/stats?stats=stat01.count.600", resp2));
         EXPECT_EQ(folly::stringPrintf("stat01.count.600=%ld\n", statCount), resp2);
 
         statCount = 0;
         statCount = StatsManager::readValue("stat01.count.3600").value();
         EXPECT_EQ(100, statCount);
         std::string resp3;
-        ASSERT_TRUE(getUrl("/stats?names=stat01.count.3600", resp3));
+        ASSERT_TRUE(getUrl("/stats?stats=stat01.count.3600", resp3));
         EXPECT_EQ(folly::stringPrintf("stat01.count.3600=%ld\n", statCount), resp3);
     }
 
     {
         // get multi stats
         std::string resp;
-        ASSERT_TRUE(getUrl("/stats?names=stat01.sum.60,stat01.avg.60,stat01.count.60", resp));
+        ASSERT_TRUE(getUrl("/stats?stats=stat01.sum.60,stat01.avg.60,stat01.count.60", resp));
         EXPECT_EQ(std::string("stat01.sum.60=5050\nstat01.avg.60=50\nstat01.count.60=100\n"), resp);
 
         // get multi stats, among invalid stat
         std::string resp1;
-        ASSERT_TRUE(getUrl("/stats?names=stat01.sum.60,stat01.avg.60,stat01.count.60,"
+        ASSERT_TRUE(getUrl("/stats?stats=stat01.sum.60,stat01.avg.60,stat01.count.60,"
                                             "stat01.p99.60", resp1));
         EXPECT_EQ(std::string("stat01.sum.60=5050\nstat01.avg.60=50\nstat01.count.60=100\n"
                               "stat01.p99.60=Invalid stats\n"), resp1);
@@ -112,7 +112,7 @@ TEST(StatsReaderTest, GetStatsTest) {
     {
         // return json
         std::string resp;
-        ASSERT_TRUE(getUrl("/stats?names=stat01.sum.60&return=json", resp));
+        ASSERT_TRUE(getUrl("/stats?stats=stat01.sum.60&format=json", resp));
         auto json = folly::parseJson(resp);
         ASSERT_TRUE(json.isArray());
         ASSERT_EQ(1UL, json.size());
@@ -124,7 +124,7 @@ TEST(StatsReaderTest, GetStatsTest) {
     {
         // get all stats(sum,count,avg,rate)
         std::string resp;
-        ASSERT_TRUE(getUrl("/stats?names= ", resp));
+        ASSERT_TRUE(getUrl("/stats?stats= ", resp));
         EXPECT_FALSE(resp.empty());
     }
 
@@ -156,21 +156,21 @@ TEST(StatsReaderTest, GetHistoTest) {
         int64_t statAvg = StatsManager::readValue("stat02.avg.60").value();
         EXPECT_EQ(50, statAvg);
         std::string resp1;
-        ASSERT_TRUE(getUrl("/stats?names=stat02.avg.60", resp1));
+        ASSERT_TRUE(getUrl("/stats?stats=stat02.avg.60", resp1));
         EXPECT_EQ(folly::stringPrintf("stat02.avg.60=%ld\n", statAvg), resp1);
 
         statAvg = 0;
         statAvg = StatsManager::readValue("stat02.Avg.600").value();
         EXPECT_EQ(50, statAvg);
         std::string resp2;
-        ASSERT_TRUE(getUrl("/stats?names=stat02.Avg.600", resp2));
+        ASSERT_TRUE(getUrl("/stats?stats=stat02.Avg.600", resp2));
         EXPECT_EQ(folly::stringPrintf("stat02.Avg.600=%ld\n", statAvg), resp2);
 
         statAvg = 0;
         statAvg = StatsManager::readValue("stat02.AVG.3600").value();
         EXPECT_EQ(50, statAvg);
         std::string resp3;
-        ASSERT_TRUE(getUrl("/stats?names=stat02.AVG.3600", resp3));
+        ASSERT_TRUE(getUrl("/stats?stats=stat02.AVG.3600", resp3));
         EXPECT_EQ(folly::stringPrintf("stat02.AVG.3600=%ld\n", statAvg), resp3);
     }
 
@@ -178,20 +178,20 @@ TEST(StatsReaderTest, GetHistoTest) {
         int64_t statP = StatsManager::readValue("stat02.p99.60").value();
         EXPECT_EQ(100, statP);
         std::string resp1;
-        ASSERT_TRUE(getUrl("/stats?names=stat02.p99.60", resp1));
+        ASSERT_TRUE(getUrl("/stats?stats=stat02.p99.60", resp1));
         EXPECT_EQ(folly::stringPrintf("stat02.p99.60=%ld\n", statP), resp1);
 
         statP = 0;
         statP = StatsManager::readValue("stat02.P99.600").value();
         EXPECT_EQ(100, statP);
         std::string resp2;
-        ASSERT_TRUE(getUrl("/stats?names=stat02.P99.600", resp2));
+        ASSERT_TRUE(getUrl("/stats?stats=stat02.P99.600", resp2));
         EXPECT_EQ(folly::stringPrintf("stat02.P99.600=%ld\n", statP), resp2);
 
         statP = 0;
         EXPECT_FALSE(StatsManager::readValue("stat02.t99.3600").ok());
         std::string resp3;
-        ASSERT_TRUE(getUrl("/stats?names=stat02.t99.3600", resp3));
+        ASSERT_TRUE(getUrl("/stats?stats=stat02.t99.3600", resp3));
         EXPECT_EQ("stat02.t99.3600=Unsupported statistic method \"t99\"\n", resp3);
     }
 }

--- a/src/common/webservice/test/TestUtils.h
+++ b/src/common/webservice/test/TestUtils.h
@@ -26,16 +26,16 @@ bool getUrl(const std::string& urlPath, std::string& respBody) {
     return true;
 }
 
-// StatusOr<std::string> putUrl(const std::string& urlPath, const folly::dynamic& data) {
-//     auto url = folly::stringPrintf(
-//         "http://%s:%d%s", FLAGS_ws_ip.c_str(), FLAGS_ws_http_port, urlPath.c_str());
-//     VLOG(1) << "Retrieving url: " << url;
+StatusOr<std::string> putUrl(const std::string& urlPath, const folly::dynamic& data) {
+    auto url = folly::stringPrintf(
+        "http://%s:%d%s", FLAGS_ws_ip.c_str(), FLAGS_ws_http_port, urlPath.c_str());
+    VLOG(1) << "Retrieving url: " << url;
 
-//     auto result = http::HttpClient::put(url.c_str(), data);
-//     if (!result.ok()) {
-//         LOG(ERROR) << "Failed to run curl: " << result.status();
-//     }
-//     return result;
-// }
+    auto result = http::HttpClient::put(url.c_str(), data);
+    if (!result.ok()) {
+        LOG(ERROR) << "Failed to run curl: " << result.status();
+    }
+    return result;
+}
 
 }  // namespace nebula

--- a/src/common/webservice/test/TestUtils.h
+++ b/src/common/webservice/test/TestUtils.h
@@ -26,4 +26,16 @@ bool getUrl(const std::string& urlPath, std::string& respBody) {
     return true;
 }
 
+// StatusOr<std::string> putUrl(const std::string& urlPath, const folly::dynamic& data) {
+//     auto url = folly::stringPrintf(
+//         "http://%s:%d%s", FLAGS_ws_ip.c_str(), FLAGS_ws_http_port, urlPath.c_str());
+//     VLOG(1) << "Retrieving url: " << url;
+
+//     auto result = http::HttpClient::put(url.c_str(), data);
+//     if (!result.ok()) {
+//         LOG(ERROR) << "Failed to run curl: " << result.status();
+//     }
+//     return result;
+// }
+
 }  // namespace nebula


### PR DESCRIPTION
This PR is originally proposed by @yixinglu :https://github.com/vesoft-inc/nebula/pull/1636

Two major changes:
1. Change update related http method to PUT and allow to update multiple flags in one time.
2. Rename GET API's filter condition like: GET graph/flags?names=minloglevel.

Related PR: https://github.com/vesoft-inc/nebula-storage/pull/354