### PR TITLE
move type related maps to header file

### DIFF
--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -3,7 +3,6 @@
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
-#include <memory>
 #include <string>
 #include <utility>
 
@@ -95,6 +94,34 @@ const Value Value::kNullOutOfRange(NullType::OUT_OF_RANGE);
 
 const uint64_t Value::kEmptyNullType = Value::Type::__EMPTY__ | Value::Type::NULLVALUE;
 const uint64_t Value::kNumericType   = Value::Type::INT | Value::Type::FLOAT;
+const std::unordered_map<Value::Type, std::string> Value::TYPE_NAME_MAP = {
+    { Value::Type::__EMPTY__, "__EMPTY__" },
+    { Value::Type::NULLVALUE, "__NULL__" },
+    { Value::Type::BOOL, "bool" },
+    { Value::Type::INT, "int" },
+    { Value::Type::FLOAT, "float" },
+    { Value::Type::STRING, "string" },
+    { Value::Type::DATE, "date" },
+    { Value::Type::TIME, "time" },
+    { Value::Type::DATETIME, "datetime" },
+    { Value::Type::VERTEX, "vertex" },
+    { Value::Type::EDGE, "edge" },
+    { Value::Type::PATH, "path" },
+    { Value::Type::LIST, "list" },
+    { Value::Type::MAP, "map" },
+    { Value::Type::SET, "set" },
+    { Value::Type::DATASET, "dataset" },
+};
+
+const std::unordered_map<NullType, std::string> Value::NULL_TYPE_NAME_MAP = {
+    { NullType::__NULL__, "__NULL__" },
+    { NullType::NaN, "NaN"},
+    { NullType::BAD_DATA, "BAD_DATA" },
+    { NullType::BAD_TYPE, "BAD_TYPE" },
+    { NullType::ERR_OVERFLOW, "ERR_OVERFLOW" },
+    { NullType::UNKNOWN_PROP, "UNKNOWN_PROP" },
+    { NullType::DIV_BY_ZERO, "DIV_BY_ZERO" },
+};
 
 Value::Value(Value&& rhs) noexcept : type_(Value::Type::__EMPTY__) {
     if (this == &rhs) { return; }
@@ -425,44 +452,15 @@ Value::Value(DataSet&& v) {
 }
 
 const std::string& Value::typeName() const {
-    static const std::unordered_map<Type, std::string> typeNames = {
-        { Type::__EMPTY__, "__EMPTY__" },
-        { Type::NULLVALUE, "__NULL__" },
-        { Type::BOOL, "bool" },
-        { Type::INT, "int" },
-        { Type::FLOAT, "float" },
-        { Type::STRING, "string" },
-        { Type::DATE, "date" },
-        { Type::TIME, "time" },
-        { Type::DATETIME, "datetime" },
-        { Type::VERTEX, "vertex" },
-        { Type::EDGE, "edge" },
-        { Type::PATH, "path" },
-        { Type::LIST, "list" },
-        { Type::MAP, "map" },
-        { Type::SET, "set" },
-        { Type::DATASET, "dataset" },
-    };
-
-    static const std::unordered_map<NullType, std::string> nullTypes = {
-        { NullType::__NULL__, "__NULL__" },
-        { NullType::NaN, "NaN"},
-        { NullType::BAD_DATA, "BAD_DATA" },
-        { NullType::BAD_TYPE, "BAD_TYPE" },
-        { NullType::ERR_OVERFLOW, "ERR_OVERFLOW" },
-        { NullType::UNKNOWN_PROP, "UNKNOWN_PROP" },
-        { NullType::DIV_BY_ZERO, "DIV_BY_ZERO" },
-    };
-
     static const std::string unknownType = "__UNKNOWN__";
 
-    auto find = typeNames.find(type_);
-    if (find == typeNames.end()) {
+    auto find = TYPE_NAME_MAP.find(type_);
+    if (find == TYPE_NAME_MAP.end()) {
         return unknownType;
     }
     if (find->first == Type::NULLVALUE) {
-        auto nullFind = nullTypes.find(value_.nVal);
-        if (nullFind == nullTypes.end()) {
+        auto nullFind = NULL_TYPE_NAME_MAP.find(value_.nVal);
+        if (nullFind == NULL_TYPE_NAME_MAP.end()) {
             return unknownType;
         }
         return nullFind->second;

--- a/src/common/datatypes/Value.h
+++ b/src/common/datatypes/Value.h
@@ -8,6 +8,7 @@
 #define COMMON_DATATYPES_VALUE_H_
 
 #include <memory>
+#include <unordered_map>
 
 #include "common/thrift/ThriftTypes.h"
 #include "common/datatypes/Date.h"
@@ -78,6 +79,8 @@ struct Value {
         DATASET   = 1UL << 14,
         NULLVALUE = 1UL << 63,
     };
+    static const std::unordered_map<Value::Type, std::string> TYPE_NAME_MAP;
+    static const std::unordered_map<NullType, std::string> NULL_TYPE_NAME_MAP;
 
     // Constructors
     Value() : type_(Type::__EMPTY__) {}


### PR DESCRIPTION
It makes more convenient to use this map in graph/storage to get type information.