### PR TITLE
Invalid host for host choosen.

### DIFF
--- a/src/common/clients/storage/StorageClientBase.h
+++ b/src/common/clients/storage/StorageClientBase.h
@@ -130,6 +130,9 @@ protected:
     void invalidLeader(GraphSpaceID spaceId, PartitionID partId);
     void invalidLeader(GraphSpaceID spaceId, std::vector<PartitionID> &partsId);
 
+    void invalidHost(const HostAddr &host);
+    void validHost(const HostAddr &host);
+
     template<class Request,
              class RemoteFunc,
              class Response =
@@ -250,6 +253,9 @@ private:
     mutable std::unordered_map<std::pair<GraphSpaceID, PartitionID>, HostAddr> leaders_;
     mutable std::atomic_bool loadLeaderBefore_{false};
     mutable std::atomic_bool isLoadingLeader_{false};
+
+    mutable folly::RWSpinLock            hostsLock_;
+    mutable std::unordered_set<HostAddr> invalidHosts_;
 };
 
 }   // namespace storage

--- a/src/common/clients/storage/StorageClientBase.inl
+++ b/src/common/clients/storage/StorageClientBase.inl
@@ -127,7 +127,7 @@ StorageClientBase<ClientType>::getLeader(const meta::PartHosts& partHosts) const
         {
             folly::RWSpinLock::ReadHolder rh(hostsLock_);
             for (const auto &host : partHosts.hosts_) {
-                if (invalidHosts_.find(host) != invalidHosts_.end()) {
+                if (invalidHosts_.find(host) == invalidHosts_.end()) {
                     leaders_[part] = host;
                     break;
                 }


### PR DESCRIPTION
NG-460
In the case if one host offline, the first request to it will failed and remove it from leaders, the later requests will choose random host from all host contains corresponding partition even the offline host, so it maybe failed too even if the new leader had elected.
Re-product by:
1. Setup up cluster,
2. insert data (sync leaders)
3. offline one host
4. insert data to offline partition
5. try 4 again

The invalid hosts maybe can't valid again so remained the random choosing logical still.