### PR TITLE
select leader in round-robin

### DIFF
--- a/src/common/clients/meta/MetaClient.cpp
+++ b/src/common/clients/meta/MetaClient.cpp
@@ -3004,7 +3004,6 @@ StatusOr<LeaderInfo> MetaClient::loadLeader() {
 
     LeaderInfo leaderInfo;
     auto hostItems = std::move(ret).value();
-    std::unordered_map<GraphSpaceID, size_t> leaderCount;
     for (auto& item : hostItems) {
         for (auto& spaceEntry : item.get_leader_parts()) {
             auto spaceName = spaceEntry.first;
@@ -3028,7 +3027,6 @@ StatusOr<LeaderInfo> MetaClient::loadLeader() {
                 }
                 leaderInfo.leaderIndex_[{spaceId, partId}] = leaderIndex;
             }
-            leaderCount[spaceId] += spaceEntry.second.size();
         }
         LOG(INFO) << "Load leader of " << item.hostAddr
                   << " in " << item.get_leader_parts().size() << " space";

--- a/src/common/clients/meta/MetaClient.cpp
+++ b/src/common/clients/meta/MetaClient.cpp
@@ -3015,6 +3015,18 @@ StatusOr<LeaderInfo> MetaClient::loadLeader() {
             auto spaceId = status.value();
             for (const auto& partId : spaceEntry.second) {
                 leaderInfo.leaderMap_[{spaceId, partId}] = item.hostAddr;
+                auto partHosts = getPartHostsFromCache(spaceId, partId);
+                size_t leaderIndex = 0;
+                if (partHosts.ok()) {
+                    const auto& peers = partHosts.value().hosts_;
+                    for (size_t i = 0; i < peers.size(); i++) {
+                        if (peers[i] == item.hostAddr) {
+                            leaderIndex = i;
+                            break;
+                        }
+                    }
+                }
+                leaderInfo.leaderIndex_[{spaceId, partId}] = leaderIndex;
             }
             leaderCount[spaceId] += spaceEntry.second.size();
         }

--- a/src/common/clients/meta/MetaClient.cpp
+++ b/src/common/clients/meta/MetaClient.cpp
@@ -3033,19 +3033,7 @@ StatusOr<LeaderInfo> MetaClient::loadLeader() {
         LOG(INFO) << "Load leader of " << item.hostAddr
                   << " in " << item.get_leader_parts().size() << " space";
     }
-    // check if all partition has elected leader in each space
-    {
-        leaderInfo.allElected_ = true;
-        folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-        for (const auto& spaceEntry : localCache_) {
-            auto spaceId = spaceEntry.first;
-            if (spaceEntry.second->partsAlloc_.size() != leaderCount[spaceId]) {
-                leaderInfo.allElected_ = false;
-                break;
-            }
-        }
-    }
-    LOG(INFO) << "Load leader ok, all elected: " << leaderInfo.allElected_;
+    LOG(INFO) << "Load leader ok";
     return leaderInfo;
 }
 

--- a/src/common/clients/meta/MetaClient.h
+++ b/src/common/clients/meta/MetaClient.h
@@ -83,8 +83,12 @@ using SpaceEdgeTypeNameMap = std::unordered_map<std::pair<GraphSpaceID, EdgeType
 // get all edgeType edgeName via spaceId
 using SpaceAllEdgeMap = std::unordered_map<GraphSpaceID, std::vector<std::string>>;
 
-// get leader host via spaceId and partId
-using LeaderMap = std::unordered_map<std::pair<GraphSpaceID, PartitionID>, HostAddr>;
+struct LeaderInfo {
+    // get leader host via spaceId and partId
+    std::unordered_map<std::pair<GraphSpaceID, PartitionID>, HostAddr> leaderMap_;
+    // indicated if meta has all leader of all spaces
+    bool allElected_;
+};
 
 using IndexStatus = std::tuple<std::string, std::string, std::string>;
 
@@ -569,7 +573,7 @@ public:
 
     Status refreshCache();
 
-    StatusOr<LeaderMap> loadLeader();
+    StatusOr<LeaderInfo> loadLeader();
 
     folly::Future<StatusOr<cpp2::StatisItem>>
     getStatis(GraphSpaceID spaceId);

--- a/src/common/clients/meta/MetaClient.h
+++ b/src/common/clients/meta/MetaClient.h
@@ -88,8 +88,6 @@ struct LeaderInfo {
     std::unordered_map<std::pair<GraphSpaceID, PartitionID>, HostAddr> leaderMap_;
     // leader index of all peers
     std::unordered_map<std::pair<GraphSpaceID, PartitionID>, size_t> leaderIndex_;
-    // indicated if meta has all leader of all spaces
-    bool allElected_;
 };
 
 using IndexStatus = std::tuple<std::string, std::string, std::string>;

--- a/src/common/clients/meta/MetaClient.h
+++ b/src/common/clients/meta/MetaClient.h
@@ -86,6 +86,8 @@ using SpaceAllEdgeMap = std::unordered_map<GraphSpaceID, std::vector<std::string
 struct LeaderInfo {
     // get leader host via spaceId and partId
     std::unordered_map<std::pair<GraphSpaceID, PartitionID>, HostAddr> leaderMap_;
+    // leader index of all peers
+    std::unordered_map<std::pair<GraphSpaceID, PartitionID>, size_t> leaderIndex_;
     // indicated if meta has all leader of all spaces
     bool allElected_;
 };

--- a/src/common/clients/storage/StorageClientBase.h
+++ b/src/common/clients/storage/StorageClientBase.h
@@ -248,7 +248,9 @@ private:
 
     mutable folly::RWSpinLock leadersLock_;
     mutable std::unordered_map<std::pair<GraphSpaceID, PartitionID>, HostAddr> leaders_;
-    mutable std::atomic_bool loadLeaderBefore_{false};
+    // record the index of hosts we pick last time
+    mutable std::unordered_map<std::pair<GraphSpaceID, PartitionID>, size_t> leaderIndex_;
+    mutable std::atomic_bool allElected_{false};
     mutable std::atomic_bool isLoadingLeader_{false};
 };
 

--- a/src/common/clients/storage/StorageClientBase.h
+++ b/src/common/clients/storage/StorageClientBase.h
@@ -248,9 +248,9 @@ private:
 
     mutable folly::RWSpinLock leadersLock_;
     mutable std::unordered_map<std::pair<GraphSpaceID, PartitionID>, HostAddr> leaders_;
+    mutable std::atomic_bool loadLeaderBefore_{false};
     // record the index of hosts we pick last time
     mutable std::unordered_map<std::pair<GraphSpaceID, PartitionID>, size_t> leaderIndex_;
-    mutable std::atomic_bool allElected_{false};
     mutable std::atomic_bool isLoadingLeader_{false};
 };
 

--- a/src/common/clients/storage/StorageClientBase.inl
+++ b/src/common/clients/storage/StorageClientBase.inl
@@ -103,6 +103,7 @@ void StorageClientBase<ClientType>::loadLeader() const {
             folly::RWSpinLock::WriteHolder wh(leadersLock_);
             auto info = status.value();
             leaders_ = std::move(info.leaderMap_);
+            leaderIndex_ = std::move(info.leaderIndex_);
             allElected_ = info.allElected_;
         }
         isLoadingLeader_ = false;

--- a/src/common/clients/storage/StorageClientBase.inl
+++ b/src/common/clients/storage/StorageClientBase.inl
@@ -92,7 +92,7 @@ StorageClientBase<ClientType>::~StorageClientBase() {
 
 template<typename ClientType>
 void StorageClientBase<ClientType>::loadLeader() const {
-    if (loadLeaderBefore_) {
+    if (allElected_) {
         return;
     }
     bool expected = false;
@@ -101,8 +101,9 @@ void StorageClientBase<ClientType>::loadLeader() const {
         auto status = metaClient_->loadLeader();
         if (status.ok()) {
             folly::RWSpinLock::WriteHolder wh(leadersLock_);
-            leaders_ = std::move(status).value();
-            loadLeaderBefore_ = true;
+            auto info = status.value();
+            leaders_ = std::move(info.leaderMap_);
+            allElected_ = info.allElected_;
         }
         isLoadingLeader_ = false;
     }
@@ -123,10 +124,12 @@ StorageClientBase<ClientType>::getLeader(const meta::PartHosts& partHosts) const
     }
     {
         folly::RWSpinLock::WriteHolder wh(leadersLock_);
-        VLOG(1) << "No leader exists. Choose one random.";
-        const auto& random = partHosts.hosts_[folly::Random::rand32(partHosts.hosts_.size())];
-        leaders_[part] = random;
-        return random;
+        VLOG(1) << "No leader exists. Choose one in round-robin.";
+        auto index = (leaderIndex_[part] + 1) % partHosts.hosts_.size();
+        auto picked = partHosts.hosts_[index];
+        leaders_[part] = picked;
+        leaderIndex_[part] = index;
+        return picked;
     }
 }
 

--- a/src/common/clients/storage/StorageClientBase.inl
+++ b/src/common/clients/storage/StorageClientBase.inl
@@ -104,6 +104,7 @@ void StorageClientBase<ClientType>::loadLeader() const {
             auto info = status.value();
             leaders_ = std::move(info.leaderMap_);
             leaderIndex_ = std::move(info.leaderIndex_);
+            loadLeaderBefore_ = true;
         }
         isLoadingLeader_ = false;
     }

--- a/src/common/clients/storage/StorageClientBase.inl
+++ b/src/common/clients/storage/StorageClientBase.inl
@@ -92,7 +92,7 @@ StorageClientBase<ClientType>::~StorageClientBase() {
 
 template<typename ClientType>
 void StorageClientBase<ClientType>::loadLeader() const {
-    if (allElected_) {
+    if (loadLeaderBefore_) {
         return;
     }
     bool expected = false;
@@ -104,7 +104,6 @@ void StorageClientBase<ClientType>::loadLeader() const {
             auto info = status.value();
             leaders_ = std::move(info.leaderMap_);
             leaderIndex_ = std::move(info.leaderIndex_);
-            allElected_ = info.allElected_;
         }
         isLoadingLeader_ = false;
     }


### PR DESCRIPTION
1. When we don't know who is leader, select in round-robin. Previously random will make us need to retry several times(some query like `lookup` need to access all leaders), until we random pick a live storage for all partition (which is hard if we have a lot partitions, I tried for 10+ times when 100 partitions). In round-robin ways, we only need to retry for a limited times if we encounter leader change.