### PR TITLE
fix nullptr ThriftClient

### DIFF
--- a/src/common/thrift/ThriftClientManager.inl
+++ b/src/common/thrift/ThriftClientManager.inl
@@ -61,8 +61,8 @@ std::shared_ptr<ClientType> ThriftClientManager<ClientType>::client(
             oss << resolved;
             LOG(INFO) << oss.str();
         } catch(const std::exception& e) {
+            // if we resolve failed, just return a connection, we will retry later
             LOG(ERROR) << e.what();
-            return nullptr;
         }
     }
 


### PR DESCRIPTION
Fix `ThriftClientManager` will return nullptr in #431, it would make all places to handle exception. We just return a bad connection when resolved failed, and wait retry later just like previous behavior.