### PR TITLE
Add agg cache

### DIFF
--- a/src/common/expression/AggregateExpression.cpp
+++ b/src/common/expression/AggregateExpression.cpp
@@ -30,6 +30,10 @@ void AggregateExpression::resetFrom(Decoder& decoder) {
     name_ = decoder.readStr();
     distinct_ = decoder.readValue().getBool();
     arg_ = decoder.readExpression();
+    auto aggFuncResult = AggFunctionManager::get(*DCHECK_NOTNULL(name_));
+    if (aggFuncResult.ok()) {
+        aggFunc_ = std::move(aggFuncResult).value();
+    }
 }
 
 const Value& AggregateExpression::eval(ExpressionContext& ctx) {
@@ -43,20 +47,17 @@ const Value& AggregateExpression::eval(ExpressionContext& ctx) {
         uniques->values.emplace(val);
     }
 
-    apply(aggData_, val);
+    DCHECK(aggFunc_);
+    aggFunc_(aggData_, val);
 
     return aggData_->result();
-}
-
-void AggregateExpression::apply(AggData* aggData, const Value& val) {
-    AggFunctionManager::get(*name_).value()(aggData, val);
 }
 
 std::string AggregateExpression::toString() const {
     // TODO fix it
     std::string arg;
     if (arg_->kind() == Expression::Kind::kConstant) {
-        const auto *argExpr = static_cast<const ConstantExpression*>(arg_.get());
+        const auto* argExpr = static_cast<const ConstantExpression*>(arg_.get());
         if (argExpr->value().isStr()) {
             arg = argExpr->value().getStr();
         } else {
@@ -77,4 +78,4 @@ std::string AggregateExpression::toString() const {
 void AggregateExpression::accept(ExprVisitor* visitor) {
     visitor->visit(this);
 }
-}  // namespace nebula
+}   // namespace nebula

--- a/src/common/expression/AggregateExpression.h
+++ b/src/common/expression/AggregateExpression.h
@@ -7,8 +7,8 @@
 #ifndef COMMON_EXPRESSION_AGGREGATEEXPRESSION_H_
 #define COMMON_EXPRESSION_AGGREGATEEXPRESSION_H_
 
-#include "common/expression/Expression.h"
 #include <common/datatypes/Set.h>
+#include "common/expression/Expression.h"
 #include "common/function/AggFunctionManager.h"
 
 namespace nebula {
@@ -17,12 +17,18 @@ class AggregateExpression final : public Expression {
 
 public:
     explicit AggregateExpression(std::string* name = nullptr,
-                        Expression* arg = nullptr,
-                        bool distinct = false)
+                                 Expression* arg = nullptr,
+                                 bool distinct = false)
         : Expression(Kind::kAggregate) {
         arg_.reset(arg);
         name_.reset(name);
         distinct_ = distinct;
+        if (name_) {
+            auto aggFuncResult = AggFunctionManager::get(*name_);
+            if (aggFuncResult.ok()) {
+                aggFunc_ = std::move(aggFuncResult).value();
+            }
+        }
     }
 
     const Value& eval(ExpressionContext& ctx) override;
@@ -37,9 +43,8 @@ public:
 
     std::unique_ptr<Expression> clone() const override {
         auto arg = arg_->clone();
-        return std::make_unique<AggregateExpression>(new std::string(*name_),
-                                                     std::move(arg).release(),
-                                                     distinct_);
+        return std::make_unique<AggregateExpression>(
+            new std::string(*name_), std::move(arg).release(), distinct_);
     }
 
     const std::string* name() const {
@@ -78,16 +83,18 @@ public:
         aggData_ = agg_data;
     }
 
-
 private:
     void writeTo(Encoder& encoder) const override;
     void resetFrom(Decoder& decoder) override;
 
-    std::unique_ptr<std::string>    name_;
-    std::unique_ptr<Expression>     arg_;
-    bool                            distinct_{false};
-    AggData*                        aggData_{nullptr};
+    std::unique_ptr<std::string> name_;
+    std::unique_ptr<Expression> arg_;
+    bool distinct_{false};
+    AggData* aggData_{nullptr};
+
+    // runtime cache for aggregate function lambda
+    AggFunctionManager::AggFunction aggFunc_;
 };
 
-}  // namespace nebula
-#endif  // EXPRESSION_AGGREGATEEXPRESSION_H_
+}   // namespace nebula
+#endif   // EXPRESSION_AGGREGATEEXPRESSION_H_

--- a/src/common/expression/test/AggregateExpressionBenchmark.cpp
+++ b/src/common/expression/test/AggregateExpressionBenchmark.cpp
@@ -1,0 +1,40 @@
+/* Copyright (c) 2021 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include <folly/Benchmark.h>
+#include <memory>
+#include "common/expression/AggregateExpression.h"
+#include "common/expression/ConstantExpression.h"
+#include "common/expression/test/ExpressionContextMock.h"
+
+nebula::ExpressionContextMock gExpCtxt;
+
+namespace nebula {
+
+static std::unique_ptr<AggregateExpression> expr = nullptr;
+
+size_t aggFuncCall(size_t iters) {
+    for (size_t i = 0; i < iters; ++i) {
+        Expression::eval(expr.get(), gExpCtxt);
+    }
+    return iters;
+}
+
+BENCHMARK_NAMED_PARAM_MULTI(aggFuncCall, AggregateExpressionBM)
+
+}   // namespace nebula
+
+int main(int argc, char** argv) {
+    nebula::expr.reset(new nebula::AggregateExpression(
+        new std::string("avg"), new nebula::ConstantExpression(2), false));
+    nebula::AggData aggData;
+    nebula::expr->setAggData(&aggData);
+
+    folly::init(&argc, &argv, true);
+    folly::runBenchmarks();
+
+    return 0;
+}

--- a/src/common/expression/test/CMakeLists.txt
+++ b/src/common/expression/test/CMakeLists.txt
@@ -70,6 +70,28 @@ nebula_add_executable(
         ${THRIFT_LIBRARIES}
 )
 
+nebula_add_executable(
+    NAME
+        aggregate_expression_bm
+    SOURCES
+        AggregateExpressionBenchmark.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:expression_obj>
+        $<TARGET_OBJECTS:datatypes_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:expr_ctx_mock_obj>
+        $<TARGET_OBJECTS:function_manager_obj>
+        $<TARGET_OBJECTS:agg_function_manager_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:time_utils_obj>
+        $<TARGET_OBJECTS:fs_obj>
+    LIBRARIES
+        follybenchmark
+        boost_regex
+        ${THRIFT_LIBRARIES}
+)
+
+
 nebula_add_test(
     NAME expression_encode_decode_test
     SOURCES EncodeDecodeTest.cpp


### PR DESCRIPTION
> 

Add aggregateExpression's runtime cache.Just Follow [https://github.com/vesoft-inc/nebula-common/pull/407](https://github.com/vesoft-inc/nebula-common/pull/407) to achieve this.

---

Benchmark:
Before this PR:
<img width="926" alt="c1" src="https://user-images.githubusercontent.com/26356194/112118703-994bd980-8bf7-11eb-93dc-382af575bfbf.png">

After this PR:
<img width="921" alt="c2" src="https://user-images.githubusercontent.com/26356194/112118724-9ea92400-8bf7-11eb-9c3f-ec6d965df4ff.png">
