### PR TITLE
Lower ThriftClientManager log level

### DIFF
--- a/src/common/base/SlowOpTracker.h
+++ b/src/common/base/SlowOpTracker.h
@@ -30,7 +30,7 @@ public:
     }
 
     void output(const std::string& prefix, const std::string& msg) {
-        LOG(INFO) << prefix << ", total time:" << dur_ << "ms, " << msg;
+        LOG(INFO) << prefix << "total time:" << dur_ << "ms, " << msg;
     }
 
 private:

--- a/src/common/thrift/ThriftClientManager.inl
+++ b/src/common/thrift/ThriftClientManager.inl
@@ -30,13 +30,13 @@ std::shared_ptr<ClientType> ThriftClientManager<ClientType>::client(
             if (channel == nullptr || !channel->good()) {
                 // Remove bad connection to create a new one.
                 clientMap_->erase(it);
-                LOG(ERROR) << "Invalid Channel: " << channel << " for host: " << host;
+                VLOG(2) << "Invalid Channel: " << channel << " for host: " << host;
                 break;
             }
             auto transport = dynamic_cast<folly::AsyncSocket*>(channel->getTransport());
             if (transport == nullptr || transport->hangup()) {
                 clientMap_->erase(it);
-                LOG(ERROR) << "Transport is closed by peers " << transport << " for host: " << host;
+                VLOG(2) << "Transport is closed by peers " << transport << " for host: " << host;
                 break;
             }
             VLOG(2) << "Getting a client to " << host;


### PR DESCRIPTION
The invalid channel log will print logs forever, especially for raft client. (chaos test will kill storage)