### PR TITLE
fixed fulltext security error

### DIFF
--- a/src/common/plugin/fulltext/FTUtils.h
+++ b/src/common/plugin/fulltext/FTUtils.h
@@ -81,7 +81,7 @@ struct HttpClient {
     std::string toString() const {
         std::stringstream os;
         if (!user.empty()) {
-            os << "-u " << user;
+            os << " -u " << user;
             if (!password.empty()) {
                 os << ":" << password;
             }


### PR DESCRIPTION
fixed fulltext security error.
the curl command parse error for user name and password. a space character is missing.