### PR TITLE
Feature/gen rust

### DIFF
--- a/cmake/ThriftGenerate.cmake
+++ b/cmake/ThriftGenerate.cmake
@@ -87,7 +87,9 @@ add_custom_command(
     --gen "csharp"
     --gen "java:hashcode"
     --gen "go:thrift_import=github.com/facebook/fbthrift/thrift/lib/go/thrift,package_prefix=github.com/vesoft-inc/nebula-go/,use_context"
+    --gen "mstch_rust"
     -o "." "${file_path}/${file_name}.thrift"
+    && mv ./gen-rust/lib.rs ./gen-rust/${file_name}.rs
   DEPENDS "${file_path}/${file_name}.thrift"
   COMMENT "Generating thrift files for ${file_name}"
 )

--- a/cmake/ThriftGenerate.cmake
+++ b/cmake/ThriftGenerate.cmake
@@ -88,7 +88,6 @@ add_custom_command(
     --gen "csharp"
     --gen "java:hashcode"
     --gen "go:thrift_import=github.com/facebook/fbthrift/thrift/lib/go/thrift,package_prefix=github.com/vesoft-inc/nebula-go/,use_context"
-    --gen "mstch_rust"
     -o "." "${file_path}/${file_name}.thrift"
     && mv ./gen-rust/lib.rs ./gen-rust/${file_name}.rs
   DEPENDS "${file_path}/${file_name}.thrift"

--- a/src/common/interface/CMakeLists.txt
+++ b/src/common/interface/CMakeLists.txt
@@ -34,5 +34,5 @@ thrift_generate("meta" "MetaService" ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT
 
 add_custom_target(
     clean-interface
-    COMMAND "rm" "-fr" "gen-cpp2" "gen-java" "gen-go" "gen-py"
+    COMMAND "rm" "-fr" "gen-cpp2" "gen-java" "gen-go" "gen-py" "gen-rust"
 )


### PR DESCRIPTION
The rust generator maybe always generate `lib.rs` file , so the file will be overwrite when generate multiple thrift file.