### PR TITLE
Transfer ownership between objectpools

### DIFF
--- a/src/common/base/ObjectPool.h
+++ b/src/common/base/ObjectPool.h
@@ -12,6 +12,7 @@
 
 #include <folly/SpinLock.h>
 
+#include "common/base/StatusOr.h"
 #include "common/cpp/helpers.h"
 
 namespace nebula {
@@ -44,11 +45,11 @@ public:
         return add(new T(std::forward<Args>(args)...));
     }
 
-    DeleteFn release(void *obj) {
+    StatusOr<DeleteFn> release(void *obj) {
         folly::SpinLockGuard g(lock_);
         auto iter = objects_.find(obj);
         if (iter == objects_.end()) {
-            return [](void *) {};
+            return Status::Error("Not found the pointer!");
         }
         auto fn = iter->second;
         objects_.erase(obj);

--- a/src/common/base/test/CMakeLists.txt
+++ b/src/common/base/test/CMakeLists.txt
@@ -105,5 +105,6 @@ target_compile_options(range_vs_transform_bm PRIVATE -O3)
 nebula_add_test(
     NAME object_pool_test
     SOURCES ObjectPoolTest.cpp
+    OBJECTS $<TARGET_OBJECTS:base_obj>
     LIBRARIES gtest gtest_main
 )

--- a/src/common/base/test/ObjectPoolTest.cpp
+++ b/src/common/base/test/ObjectPoolTest.cpp
@@ -41,7 +41,9 @@ TEST(ObjectPoolTest, TestTransfer) {
     ObjectPool p1, p2;
     auto ptr = new MyClass;
     ASSERT_EQ(p1.add(ptr), ptr);
-    ASSERT_EQ(p2.add(ptr, p1.release(ptr)), ptr);
+    auto status = p1.release(ptr);
+    ASSERT(status.ok());
+    ASSERT_EQ(p2.add(ptr, std::move(status).value()), ptr);
 
     p1.clear();
     p2.clear();


### PR DESCRIPTION
Sometimes we need to transfer some object ownerships to another pool for releasing current pool early. e.g. in optimizer of graph, we can only save the used plan nodes in `QueryContext` when finishing optimization, other nodes could be destroyed with the release of OptGroups.