### PR TITLE
[OpenCypher Compatibility] Support timestamp() with empty parameter

### DIFF
--- a/src/common/function/FunctionManager.cpp
+++ b/src/common/function/FunctionManager.cpp
@@ -197,8 +197,9 @@ std::unordered_map<std::string, std::vector<TypeSignature>> FunctionManager::typ
     {"datetime", {TypeSignature({}, Value::Type::DATETIME),
               TypeSignature({Value::Type::STRING}, Value::Type::DATETIME),
               TypeSignature({Value::Type::MAP}, Value::Type::DATETIME)}},
-    {"timestamp", {TypeSignature({Value::Type::STRING}, Value::Type::INT),
-                   TypeSignature({Value::Type::INT}, Value::Type::INT)}},
+    {"timestamp", {TypeSignature({}, Value::Type::INT),
+                TypeSignature({Value::Type::STRING}, Value::Type::INT),
+                TypeSignature({Value::Type::INT}, Value::Type::INT)}},
     {"tags", {TypeSignature({Value::Type::VERTEX}, Value::Type::LIST),
              }},
     {"labels", {TypeSignature({Value::Type::VERTEX}, Value::Type::LIST),
@@ -1581,9 +1582,13 @@ FunctionManager::FunctionManager() {
     }
     {
         auto &attr = functions_["timestamp"];
-        attr.minArity_ = 1;
+        attr.minArity_ = 0;
         attr.maxArity_ = 1;
+        attr.isPure_ = false;
         attr.body_ = [](const auto &args) -> Value {
+            if (args.size() == 0) {
+                return time::WallClock::fastNowInSec();
+            }
             auto status = time::TimeUtils::toTimestamp(args[0]);
             if (!status.ok()) {
                 return Value::kNullBadData;

--- a/src/common/function/test/FunctionManagerTest.cpp
+++ b/src/common/function/test/FunctionManagerTest.cpp
@@ -794,6 +794,11 @@ TEST_F(FunctionManagerTest, functionCall) {
         EXPECT_EQ(res, 1602324000);
     }
     {
+        auto result = FunctionManager::get("timestamp", {});
+        ASSERT_TRUE(result.ok());
+        EXPECT_EQ(result.value(), Value::Type::INT);
+    }
+    {
         TEST_FUNCTION(e, args_["empty"], M_E);
         TEST_FUNCTION(pi, args_["empty"], M_PI);
         TEST_FUNCTION(radians, args_["radians"], M_PI);

--- a/src/common/function/test/FunctionManagerTest.cpp
+++ b/src/common/function/test/FunctionManagerTest.cpp
@@ -796,7 +796,8 @@ TEST_F(FunctionManagerTest, functionCall) {
     {
         auto result = FunctionManager::get("timestamp", {});
         ASSERT_TRUE(result.ok());
-        EXPECT_EQ(result.value(), Value::Type::INT);
+        auto res = std::move(result).value()({});
+        EXPECT_EQ(res.type(), Value::Type::INT);
     }
     {
         TEST_FUNCTION(e, args_["empty"], M_E);


### PR DESCRIPTION
support `timestamp()` to take empty arguments. The functionality is the same as `now()`.

Fixes https://github.com/vesoft-inc/nebula-graph/issues/811