### PR TITLE
Fix Integer overflow

### DIFF
--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -1925,11 +1925,11 @@ Value operator+(const Value& lhs, const Value& rhs) {
                 case Value::Type::INT: {
                     auto lVal = lhs.getInt();
                     auto rVal = rhs.getInt();
-                    if ((lVal > 0 && rVal > INT64_MAX - lVal) ||
-                        (lVal < 0 && rVal < INT64_MIN - lVal)) {
+                    int sum;
+                    if (__builtin_add_overflow(lVal, rVal, &sum)) {
                         return Value::kNullOverflow;
                     }
-                    return lVal + rVal;
+                    return sum;
                 }
                 case Value::Type::FLOAT: {
                     return lhs.getInt() + rhs.getFloat();
@@ -2179,11 +2179,11 @@ Value operator-(const Value& lhs, const Value& rhs) {
                 case Value::Type::INT: {
                     auto lVal = lhs.getInt();
                     auto rVal = rhs.getInt();
-                    if ((rVal < 0 && lVal > INT64_MAX + rVal) ||
-                        (rVal > 0 && lVal < INT64_MIN + rVal)) {
+                    int res;
+                    if (__builtin_sub_overflow(lVal, rVal, &res)) {
                         return Value::kNullOverflow;
                     }
-                    return lVal - rVal;
+                    return res;
                 }
                 case Value::Type::FLOAT: {
                     return lhs.getInt() - rhs.getFloat();
@@ -2244,10 +2244,11 @@ Value operator*(const Value& lhs, const Value& rhs) {
                     if ((lVal == -1 && rVal == INT64_MIN) || (rVal == -1 && lVal == INT64_MIN)) {
                         return Value::kNullOverflow;
                     }
-                    if ((lVal > INT64_MAX / rVal) || (lVal < INT64_MIN / rVal)) {
+                    int res;
+                    if (__builtin_mul_overflow(lVal, rVal, &res)) {
                         return Value::kNullOverflow;
                     }
-                    return lVal * rVal;
+                    return res;
                 }
                 case Value::Type::FLOAT: {
                     return lhs.getInt() * rhs.getFloat();

--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -451,6 +451,7 @@ const std::string& Value::typeName() const {
         { NullType::BAD_DATA, "BAD_DATA" },
         { NullType::BAD_TYPE, "BAD_TYPE" },
         { NullType::ERR_OVERFLOW, "ERR_OVERFLOW" },
+        { NullType::ERR_UNDERFLOW, "ERR_UNDERFLOW" },
         { NullType::UNKNOWN_PROP, "UNKNOWN_PROP" },
         { NullType::DIV_BY_ZERO, "DIV_BY_ZERO" },
     };
@@ -2183,9 +2184,9 @@ Value operator-(const Value& lhs, const Value& rhs) {
                 case Value::Type::INT: {
                     auto lVal = lhs.getInt();
                     auto rVal = rhs.getInt();
-                    if (lVal < 0 && rVal > INT64_MAX + lVal) {
+                    if (rVal < 0 && lVal > INT64_MAX + rVal) {
                         return Value::kNullOverflow;
-                    } else if (lVal > 0 && rVal < INT64_MIN + lVal) {
+                    } else if (rVal > 0 && lVal < INT64_MIN + rVal) {
                         return Value::kNullUnderflow;
                     }
                     return lVal - rVal;
@@ -2249,7 +2250,7 @@ Value operator*(const Value& lhs, const Value& rhs) {
                     if ((lVal == -1 && rVal == INT64_MIN) || (rVal == -1 && lVal == INT64_MIN)) {
                         return Value::kNullOverflow;
                     }
-                    if (lVal > INT64_MAX / rVal || lVal < INT64_MIN / rVal) {
+                    if (lVal > INT64_MAX / rVal) {
                         return Value::kNullOverflow;
                     } else if (lVal < INT64_MIN / rVal) {
                         return Value::kNullUnderflow;

--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -2418,7 +2418,11 @@ Value operator-(const Value& rhs) {
 
     switch (rhs.type()) {
         case Value::Type::INT: {
-            auto val = -rhs.getInt();
+            auto rVal = rhs.getInt();
+            if (rVal == INT64_MIN) {
+                return Value::kNullOverflow;
+            }
+            auto val = -rVal;
             return val;
         }
         case Value::Type::FLOAT: {

--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -2411,9 +2411,9 @@ Value operator-(const Value& rhs) {
     switch (rhs.type()) {
         case Value::Type::INT: {
             auto rVal = rhs.getInt();
-            // if (rVal == INT64_MIN) {
-            //     return Value::kNullOverflow;
-            // }
+            if (rVal == INT64_MIN) {
+                return Value::kNullOverflow;
+            }
             auto val = -rVal;
             return val;
         }

--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -1923,9 +1923,9 @@ Value operator+(const Value& lhs, const Value& rhs) {
         case Value::Type::INT: {
             switch (rhs.type()) {
                 case Value::Type::INT: {
-                    auto lVal = lhs.getInt();
-                    auto rVal = rhs.getInt();
-                    int sum;
+                    int64_t lVal = lhs.getInt();
+                    int64_t rVal = rhs.getInt();
+                    int64_t sum;
                     if (__builtin_add_overflow(lVal, rVal, &sum)) {
                         return Value::kNullOverflow;
                     }
@@ -2177,9 +2177,9 @@ Value operator-(const Value& lhs, const Value& rhs) {
         case Value::Type::INT: {
             switch (rhs.type()) {
                 case Value::Type::INT: {
-                    auto lVal = lhs.getInt();
-                    auto rVal = rhs.getInt();
-                    int res;
+                    int64_t lVal = lhs.getInt();
+                    int64_t rVal = rhs.getInt();
+                    int64_t res;
                     if (__builtin_sub_overflow(lVal, rVal, &res)) {
                         return Value::kNullOverflow;
                     }
@@ -2238,13 +2238,13 @@ Value operator*(const Value& lhs, const Value& rhs) {
         case Value::Type::INT: {
             switch (rhs.type()) {
                 case Value::Type::INT: {
-                    auto lVal = lhs.getInt();
-                    auto rVal = rhs.getInt();
+                    int64_t lVal = lhs.getInt();
+                    int64_t rVal = rhs.getInt();
                     // -1 * min causes overflow
                     if ((lVal == -1 && rVal == INT64_MIN) || (rVal == -1 && lVal == INT64_MIN)) {
                         return Value::kNullOverflow;
                     }
-                    int res;
+                    int64_t res;
                     if (__builtin_mul_overflow(lVal, rVal, &res)) {
                         return Value::kNullOverflow;
                     }
@@ -2294,7 +2294,7 @@ Value operator/(const Value& lhs, const Value& rhs) {
                     if (denom == 0) {
                         return Value::kNullDivByZero;
                     }
-                    auto lVal = lhs.getInt();
+                    int64_t lVal = lhs.getInt();
                     // INT_MIN/-1 causes overflow
                     if (lVal == INT64_MIN && denom == -1) {
                         return Value::kNullOverflow;
@@ -2411,7 +2411,7 @@ Value operator-(const Value& rhs) {
 
     switch (rhs.type()) {
         case Value::Type::INT: {
-            auto rVal = rhs.getInt();
+            int64_t rVal = rhs.getInt();
             if (rVal == INT64_MIN) {
                 return Value::kNullOverflow;
             }

--- a/src/common/datatypes/Value.h
+++ b/src/common/datatypes/Value.h
@@ -41,6 +41,7 @@ enum class NullType {
     UNKNOWN_PROP = 5,
     DIV_BY_ZERO = 6,
     OUT_OF_RANGE = 7,
+    ERR_UNDERFLOW = 8,
 };
 
 
@@ -51,6 +52,7 @@ struct Value {
     static const Value kNullBadData;
     static const Value kNullBadType;
     static const Value kNullOverflow;
+    static const Value kNullUnderflow;
     static const Value kNullUnknownProp;
     static const Value kNullDivByZero;
     static const Value kNullOutOfRange;

--- a/src/common/datatypes/Value.h
+++ b/src/common/datatypes/Value.h
@@ -41,7 +41,6 @@ enum class NullType {
     UNKNOWN_PROP = 5,
     DIV_BY_ZERO = 6,
     OUT_OF_RANGE = 7,
-    ERR_UNDERFLOW = 8,
 };
 
 
@@ -52,7 +51,6 @@ struct Value {
     static const Value kNullBadData;
     static const Value kNullBadType;
     static const Value kNullOverflow;
-    static const Value kNullUnderflow;
     static const Value kNullUnknownProp;
     static const Value kNullDivByZero;
     static const Value kNullOutOfRange;

--- a/src/common/datatypes/test/ValueTest.cpp
+++ b/src/common/datatypes/test/ValueTest.cpp
@@ -44,6 +44,14 @@ TEST(Value, Arithmetics) {
         EXPECT_EQ(Value::Type::INT, v.type());
         EXPECT_EQ(3L, v.getInt());
 
+        // overflow
+        v = Value(INT64_MAX) + 1;
+        EXPECT_EQ(Value::kNullOverflow, v);
+
+        // underflow
+        v = Value(INT64_MIN) + -1;
+        EXPECT_EQ(Value::kNullUnderflow, v);
+
         v = vFloat1 + vFloat2;
         EXPECT_EQ(Value::Type::FLOAT, v.type());
         EXPECT_DOUBLE_EQ(5.81, v.getFloat());
@@ -122,6 +130,14 @@ TEST(Value, Arithmetics) {
         EXPECT_EQ(Value::Type::INT, v.type());
         EXPECT_EQ(-1L, v.getInt());
 
+        // overflow
+        v = Value(INT64_MAX) - -1;
+        EXPECT_EQ(Value::kNullOverflow, v);
+
+        // underflow
+        v = Value(INT64_MIN) - 1;
+        EXPECT_EQ(Value::kNullUnderflow, v);
+
         v = vFloat1 - vFloat2;
         EXPECT_EQ(Value::Type::FLOAT, v.type());
         EXPECT_DOUBLE_EQ(0.47, v.getFloat());
@@ -144,6 +160,19 @@ TEST(Value, Arithmetics) {
         EXPECT_EQ(Value::Type::INT, v.type());
         EXPECT_EQ((vInt2.getInt() * vInt2.getInt()), v.getInt());
 
+        // overflow
+        v = Value(INT64_MAX) * 2;
+        EXPECT_EQ(Value::kNullOverflow, v);
+        // edge case -1 * MIN  =>  overflow
+        v = Value(INT64_MIN) * -1;
+        EXPECT_EQ(Value::kNullOverflow, v);
+        v = -1 * Value(INT64_MIN);
+        EXPECT_EQ(Value::kNullOverflow, v);
+
+        // underflow
+        v = Value(INT64_MIN) * 2;
+        EXPECT_EQ(Value::kNullUnderflow, v);
+
         v = vInt2 * vFloat1;
         EXPECT_EQ(Value::Type::FLOAT, v.type());
         EXPECT_EQ((vInt2.getInt() * vFloat1.getFloat()), v.getFloat());
@@ -162,6 +191,10 @@ TEST(Value, Arithmetics) {
         Value v = vInt2 / vInt2;
         EXPECT_EQ(Value::Type::INT, v.type());
         EXPECT_EQ((vInt2.getInt() / vInt2.getInt()), v.getInt());
+
+        // overflow
+        v = Value(INT64_MIN) / -1;
+        EXPECT_EQ(Value::kNullOverflow, v);
 
         v = vInt2 / vFloat1;
         EXPECT_EQ(Value::Type::FLOAT, v.type());
@@ -868,6 +901,7 @@ TEST(Value, typeName) {
     EXPECT_EQ("BAD_DATA", Value::kNullBadData.typeName());
     EXPECT_EQ("BAD_TYPE", Value::kNullBadType.typeName());
     EXPECT_EQ("ERR_OVERFLOW", Value::kNullOverflow.typeName());
+    EXPECT_EQ("ERR_UNDERFLOW", Value::kNullUnderflow.typeName());
     EXPECT_EQ("UNKNOWN_PROP", Value::kNullUnknownProp.typeName());
     EXPECT_EQ("DIV_BY_ZERO", Value::kNullDivByZero.typeName());
 }
@@ -884,6 +918,7 @@ TEST(Value, DecodeEncode) {
         Value(NullType::DIV_BY_ZERO),
         Value(NullType::BAD_DATA),
         Value(NullType::ERR_OVERFLOW),
+        Value(NullType::ERR_UNDERFLOW),
         Value(NullType::OUT_OF_RANGE),
         Value(NullType::UNKNOWN_PROP),
 

--- a/src/common/datatypes/test/ValueTest.cpp
+++ b/src/common/datatypes/test/ValueTest.cpp
@@ -47,10 +47,8 @@ TEST(Value, Arithmetics) {
         // overflow
         v = Value(INT64_MAX) + 1;
         EXPECT_EQ(Value::kNullOverflow, v);
-
-        // underflow
         v = Value(INT64_MIN) + -1;
-        EXPECT_EQ(Value::kNullUnderflow, v);
+        EXPECT_EQ(Value::kNullOverflow, v);
 
         v = vFloat1 + vFloat2;
         EXPECT_EQ(Value::Type::FLOAT, v.type());
@@ -133,10 +131,8 @@ TEST(Value, Arithmetics) {
         // overflow
         v = Value(INT64_MAX) - -1;
         EXPECT_EQ(Value::kNullOverflow, v);
-
-        // underflow
         v = Value(INT64_MIN) - 1;
-        EXPECT_EQ(Value::kNullUnderflow, v);
+        EXPECT_EQ(Value::kNullOverflow, v);
 
         v = vFloat1 - vFloat2;
         EXPECT_EQ(Value::Type::FLOAT, v.type());
@@ -168,10 +164,8 @@ TEST(Value, Arithmetics) {
         EXPECT_EQ(Value::kNullOverflow, v);
         v = -1 * Value(INT64_MIN);
         EXPECT_EQ(Value::kNullOverflow, v);
-
-        // underflow
         v = Value(INT64_MIN) * 2;
-        EXPECT_EQ(Value::kNullUnderflow, v);
+        EXPECT_EQ(Value::kNullOverflow, v);
 
         v = vInt2 * vFloat1;
         EXPECT_EQ(Value::Type::FLOAT, v.type());
@@ -905,7 +899,6 @@ TEST(Value, typeName) {
     EXPECT_EQ("BAD_DATA", Value::kNullBadData.typeName());
     EXPECT_EQ("BAD_TYPE", Value::kNullBadType.typeName());
     EXPECT_EQ("ERR_OVERFLOW", Value::kNullOverflow.typeName());
-    EXPECT_EQ("ERR_UNDERFLOW", Value::kNullUnderflow.typeName());
     EXPECT_EQ("UNKNOWN_PROP", Value::kNullUnknownProp.typeName());
     EXPECT_EQ("DIV_BY_ZERO", Value::kNullDivByZero.typeName());
 }
@@ -922,7 +915,6 @@ TEST(Value, DecodeEncode) {
         Value(NullType::DIV_BY_ZERO),
         Value(NullType::BAD_DATA),
         Value(NullType::ERR_OVERFLOW),
-        Value(NullType::ERR_UNDERFLOW),
         Value(NullType::OUT_OF_RANGE),
         Value(NullType::UNKNOWN_PROP),
 

--- a/src/common/datatypes/test/ValueTest.cpp
+++ b/src/common/datatypes/test/ValueTest.cpp
@@ -248,6 +248,10 @@ TEST(Value, Arithmetics) {
         EXPECT_EQ(Value::Type::FLOAT, v.type());
         EXPECT_DOUBLE_EQ(-3.14, v.getFloat());
 
+        // Overflow
+        v = -Value(INT64_MIN);
+        EXPECT_EQ(Value::kNullOverflow, v);
+
         v = !vBool1;
         EXPECT_EQ(Value::Type::BOOL, v.type());
         EXPECT_DOUBLE_EQ(true, v.getBool());


### PR DESCRIPTION
As title.

```
(root@nebula) [nba]> yield 9223372036854775807 + 1
[ERROR (-8)]: (9223372036854775807+1) cannot be represented as an integer

(root@nebula) [nba]> yield 9223372036854775807/0
[ERROR (-8)]: / by zero
```
Required by https://github.com/vesoft-inc/nebula-graph/pull/1043
