### PR TITLE
Fix bug: emplace only do insertion when key does not exists.

### DIFF
--- a/src/common/clients/meta/MetaClient.cpp
+++ b/src/common/clients/meta/MetaClient.cpp
@@ -440,7 +440,7 @@ bool MetaClient::loadIndexes(GraphSpaceID spaceId,
         auto indexName = tagIndex.get_index_name();
         auto indexID = tagIndex.get_index_id();
         std::pair<GraphSpaceID, std::string> pair(spaceId, indexName);
-        tagNameIndexMap_.emplace(std::move(pair), indexID);
+        tagNameIndexMap_[pair] = indexID;
         auto tagIndexPtr = std::make_shared<cpp2::IndexItem>(tagIndex);
         tagIndexes.emplace(indexID, tagIndexPtr);
     }
@@ -451,7 +451,7 @@ bool MetaClient::loadIndexes(GraphSpaceID spaceId,
         auto indexName = edgeIndex.get_index_name();
         auto indexID = edgeIndex.get_index_id();
         std::pair<GraphSpaceID, std::string> pair(spaceId, indexName);
-        edgeNameIndexMap_.emplace(std::move(pair), indexID);
+        edgeNameIndexMap_[pair] = indexID;
         auto edgeIndexPtr = std::make_shared<cpp2::IndexItem>(edgeIndex);
         edgeIndexes.emplace(indexID, edgeIndexPtr);
     }


### PR DESCRIPTION
Steps to reproduce this issue:
1. create a index:
(root@nebula) [basketballplayer]> create tag index name on player(name(20));
Execution succeeded (time spent 2989/3376 us)

2. drop the index:
(root@nebula) [basketballplayer]> drop tag index name
Execution succeeded (time spent 2750/3179 us)

3. create the index again:
(root@nebula) [basketballplayer]> create tag index name on player(name(20));
Execution succeeded (time spent 2989/3376 us)

4. drop the index again will return fails:
(root@nebula) [basketballplayer]> drop tag index name;
[ERROR (-12)]: SemanticError: index name was not found

the root cause is that  edgeNameIndexMap_.emplace(std::move(pair), indexID) does not update edgeNameIndexMap_ as old key exists.