### PR TITLE
Add rawString interface for expression

### DIFF
--- a/src/common/expression/Expression.h
+++ b/src/common/expression/Expression.h
@@ -131,6 +131,10 @@ public:
 
     virtual std::string toString() const = 0;
 
+    virtual std::string rawString() const {
+        return toString();
+    }
+
     virtual void accept(ExprVisitor* visitor) = 0;
 
     // Deep copy

--- a/src/common/expression/ListComprehensionExpression.cpp
+++ b/src/common/expression/ListComprehensionExpression.cpp
@@ -139,13 +139,6 @@ void ListComprehensionExpression::resetFrom(Decoder& decoder) {
 }
 
 std::string ListComprehensionExpression::toString() const {
-    if (originString_ != nullptr) {
-        return *originString_;
-    }
-    return makeString();
-}
-
-std::string ListComprehensionExpression::makeString() const {
     std::string buf;
     buf.reserve(256);
 

--- a/src/common/expression/ListComprehensionExpression.h
+++ b/src/common/expression/ListComprehensionExpression.h
@@ -31,6 +31,10 @@ public:
 
     std::string toString() const override;
 
+    std::string rawString() const override {
+        return hasOriginString() ? *originString_ : "";
+    }
+
     void accept(ExprVisitor* visitor) override;
 
     std::unique_ptr<Expression> clone() const override;
@@ -94,8 +98,6 @@ public:
     void setOriginString(std::string* s) {
         originString_.reset(s);
     }
-
-    std::string makeString() const;
 
     bool hasOriginString() const {
         return originString_ != nullptr;

--- a/src/common/expression/PredicateExpression.cpp
+++ b/src/common/expression/PredicateExpression.cpp
@@ -236,13 +236,6 @@ void PredicateExpression::resetFrom(Decoder& decoder) {
 }
 
 std::string PredicateExpression::toString() const {
-    if (originString_ != nullptr) {
-        return *originString_;
-    }
-    return makeString();
-}
-
-std::string PredicateExpression::makeString() const {
     std::string buf;
     buf.reserve(256);
 

--- a/src/common/expression/PredicateExpression.h
+++ b/src/common/expression/PredicateExpression.h
@@ -39,6 +39,10 @@ public:
 
     std::string toString() const override;
 
+    std::string rawString() const override {
+        return hasOriginString() ? *originString_ : "";
+    }
+
     void accept(ExprVisitor* visitor) override;
 
     std::unique_ptr<Expression> clone() const override;
@@ -90,8 +94,6 @@ public:
     void setOriginString(std::string* s) {
         originString_.reset(s);
     }
-
-    std::string makeString() const;
 
     bool hasOriginString() const {
         return originString_ != nullptr;

--- a/src/common/expression/ReduceExpression.cpp
+++ b/src/common/expression/ReduceExpression.cpp
@@ -105,14 +105,6 @@ void ReduceExpression::resetFrom(Decoder& decoder) {
 }
 
 std::string ReduceExpression::toString() const {
-    if (originString_ != nullptr) {
-        return *originString_;
-    } else {
-        return makeString();
-    }
-}
-
-std::string ReduceExpression::makeString() const {
     std::string buf;
     buf.reserve(256);
 

--- a/src/common/expression/ReduceExpression.h
+++ b/src/common/expression/ReduceExpression.h
@@ -33,6 +33,10 @@ public:
 
     std::string toString() const override;
 
+    std::string rawString() const override {
+        return hasOriginString() ? *originString_ : "";
+    }
+
     void accept(ExprVisitor* visitor) override;
 
     std::unique_ptr<Expression> clone() const override;
@@ -100,8 +104,6 @@ public:
     void setOriginString(std::string* s) {
         originString_.reset(s);
     }
-
-    std::string makeString() const;
 
     bool hasOriginString() const {
         return originString_ != nullptr;


### PR DESCRIPTION
When we print execution plan, we expect the rewrited expr string. And we can response the raw expr string result to user by this interface if needed.