### PR TITLE
count buffer/cache into MemInfo

### DIFF
--- a/src/common/base/Memory.h
+++ b/src/common/base/Memory.h
@@ -29,8 +29,12 @@ public:
         return (info_->freeram * info_->mem_unit) >> 10;
     }
 
+    uint64_t bufferInKB() const {
+        return (info_->bufferram * info_->mem_unit) >> 10;
+    }
+
     uint64_t usedInKB() const {
-        return totalInKB() - freeInKB();
+        return totalInKB() - freeInKB() - bufferInKB();
     }
 
     bool hitsHighWatermark(float ratio = 0.8f) const {

--- a/src/common/base/test/MemoryTest.cpp
+++ b/src/common/base/test/MemoryTest.cpp
@@ -15,7 +15,9 @@ TEST(MemInfoTest, TestMemInfo) {
     ASSERT(status.ok());
     auto mem = std::move(status).value();
     ASSERT_GE(mem->totalInKB(), mem->usedInKB());
-    ASSERT_EQ(mem->totalInKB(), mem->usedInKB() + mem->freeInKB());
+    ASSERT_GE(mem->totalInKB(), mem->freeInKB());
+    ASSERT_GE(mem->totalInKB(), mem->bufferInKB());
+    ASSERT_EQ(mem->totalInKB(), mem->usedInKB() + mem->freeInKB() + mem->bufferInKB());
 
     float ratio = static_cast<double>(mem->usedInKB() - 100) / mem->totalInKB();
     ASSERT(mem->hitsHighWatermark(ratio));


### PR DESCRIPTION
`Total = Used + Free + Buffer/Cache`

Maybe need to take buffer/cache into consideration, here a screenshot when I do some test.

![image](https://user-images.githubusercontent.com/13706157/120139238-9fb78c80-c20a-11eb-9763-f8f969483b13.png)

Graph will keep logging something like `Used memory(211303932KB) hits the high watermark(0.800000) of total system memory(263856036KB).`.

PR is still in verification.