### PR TITLE
load leader info by heartbeat

### DIFF
--- a/src/common/clients/meta/MetaClient.cpp
+++ b/src/common/clients/meta/MetaClient.cpp
@@ -270,6 +270,9 @@ bool MetaClient::loadData() {
         [] (auto &hostItem) -> HostAddr {
             return *hostItem.hostAddr_ref();
         });
+
+    loadLeader(hostItems, spaceIndexByName_);
+
     decltype(localCache_) oldCache;
     {
         folly::RWSpinLock::WriteHolder holder(localCacheLock_);
@@ -2302,6 +2305,58 @@ MetaClient::getEdgeIndexesFromCache(GraphSpaceID spaceId) {
     }
 }
 
+StatusOr<HostAddr>
+MetaClient::getStorageLeaderFromCache(GraphSpaceID spaceId, PartitionID partId) {
+    if (!ready_) {
+        return Status::Error("Not ready!");
+    }
+
+    {
+        folly::RWSpinLock::ReadHolder holder(leadersLock_);
+        auto iter = leadersInfo_.leaderMap_.find({spaceId, partId});
+        if (iter != leadersInfo_.leaderMap_.end()) {
+            return iter->second;
+        }
+    }
+    {
+        // no leader found, pick one in round-robin
+        auto partHostsRet = getPartHostsFromCache(spaceId, partId);
+        if (!partHostsRet.ok()) {
+            return partHostsRet.status();
+        }
+        auto partHosts = partHostsRet.value();
+        folly::RWSpinLock::WriteHolder wh(leadersLock_);
+        VLOG(1) << "No leader exists. Choose one in round-robin.";
+        auto index = (leadersInfo_.pickedIndex_[{spaceId, partId}] + 1) % partHosts.hosts_.size();
+        auto picked = partHosts.hosts_[index];
+        leadersInfo_.leaderMap_[{spaceId, partId}] = picked;
+        leadersInfo_.pickedIndex_[{spaceId, partId}] = index;
+        return picked;
+    }
+}
+
+void MetaClient::updateStorageLeader(GraphSpaceID spaceId,
+                                     PartitionID partId,
+                                     const HostAddr& leader) {
+    VLOG(1) << "Update the leader for [" << spaceId << ", " << partId << "] to " << leader;
+    folly::RWSpinLock::WriteHolder holder(leadersLock_);
+    leadersInfo_.leaderMap_[{spaceId, partId}] = leader;
+}
+
+void MetaClient::invalidStorageLeader(GraphSpaceID spaceId,
+                                      PartitionID partId) {
+    VLOG(1) << "Invalidate the leader for [" << spaceId << ", " << partId << "]";
+    folly::RWSpinLock::WriteHolder holder(leadersLock_);
+    leadersInfo_.leaderMap_.erase({spaceId, partId});
+}
+
+StatusOr<LeaderInfo> MetaClient::getLeaderInfo() {
+    if (!ready_) {
+        return Status::Error("Not ready!");
+    }
+    folly::RWSpinLock::ReadHolder holder(leadersLock_);
+    return leadersInfo_;
+}
 
 const std::vector<HostAddr>& MetaClient::getAddresses() {
     return addrs_;
@@ -3103,27 +3158,18 @@ Status MetaClient::refreshCache() {
 }
 
 
-StatusOr<LeaderInfo> MetaClient::loadLeader() {
-    // Return error if has not loadData before
-    if (!ready_) {
-        return Status::Error("Not ready!");
-    }
-
-    auto ret = listHosts().get();
-    if (!ret.ok()) {
-        return Status::Error("List hosts failed");
-    }
-
+void MetaClient::loadLeader(const std::vector<cpp2::HostItem>& hostItems,
+                            const SpaceNameIdMap& spaceIndexByName) {
     LeaderInfo leaderInfo;
-    auto hostItems = std::move(ret).value();
     for (auto& item : hostItems) {
         for (auto& spaceEntry : item.get_leader_parts()) {
             auto spaceName = spaceEntry.first;
-            auto status = getSpaceIdByNameFromCache(spaceName);
-            if (!status.ok()) {
+            // ready_ is still false, can't read from cache
+            auto iter = spaceIndexByName.find(spaceName);
+            if (iter == spaceIndexByName.end()) {
                 continue;
             }
-            auto spaceId = status.value();
+            auto spaceId = iter->second;
             for (const auto& partId : spaceEntry.second) {
                 leaderInfo.leaderMap_[{spaceId, partId}] = item.get_hostAddr();
                 auto partHosts = getPartHostsFromCache(spaceId, partId);
@@ -3137,14 +3183,19 @@ StatusOr<LeaderInfo> MetaClient::loadLeader() {
                         }
                     }
                 }
-                leaderInfo.leaderIndex_[{spaceId, partId}] = leaderIndex;
+                leaderInfo.pickedIndex_[{spaceId, partId}] = leaderIndex;
             }
         }
         LOG(INFO) << "Load leader of " << item.get_hostAddr()
                   << " in " << item.get_leader_parts().size() << " space";
     }
-    LOG(INFO) << "Load leader ok";
-    return leaderInfo;
+    {
+        // todo(doodle): in worst case, storage and meta isolated, so graph may get a outdate
+        // leader info. The problem could be solved if leader term are cached as well.
+        LOG(INFO) << "Load leader ok";
+        folly::RWSpinLock::WriteHolder wh(leadersLock_);
+        leadersInfo_ = std::move(leaderInfo);
+    }
 }
 
 folly::Future<StatusOr<bool>>

--- a/src/common/clients/storage/StorageClientBase.h
+++ b/src/common/clients/storage/StorageClientBase.h
@@ -124,7 +124,6 @@ protected:
                       meta::MetaClient* metaClient);
     virtual ~StorageClientBase();
 
-    virtual void loadLeader() const;
     StatusOr<HostAddr> getLeader(GraphSpaceID spaceId, PartitionID partId) const;
     void updateLeader(GraphSpaceID spaceId, PartitionID partId, const HostAddr& leader);
     void invalidLeader(GraphSpaceID spaceId, PartitionID partId);
@@ -245,13 +244,6 @@ protected:
 private:
     std::shared_ptr<folly::IOThreadPoolExecutor> ioThreadPool_;
     std::unique_ptr<thrift::ThriftClientManager<ClientType>> clientsMan_;
-
-    mutable folly::RWSpinLock leadersLock_;
-    mutable std::unordered_map<std::pair<GraphSpaceID, PartitionID>, HostAddr> leaders_;
-    mutable std::atomic_bool loadLeaderBefore_{false};
-    // record the index of hosts we pick last time
-    mutable std::unordered_map<std::pair<GraphSpaceID, PartitionID>, size_t> leaderIndex_;
-    mutable std::atomic_bool isLoadingLeader_{false};
 };
 
 }   // namespace storage


### PR DESCRIPTION
Load leader info by heartbeat from meta, this feature was meant to be merged in 2.0 GA. However https://github.com/vesoft-inc/nebula-common/pull/455 involves with some behavior changes.

This PR merely move every leader process from StorageClient to MetaClient. MetaClient will update leader info once distribution changed, and storage client will modify it according storage response.