### PR TITLE
Workaround to fix clang build on aarch64

### DIFF
--- a/src/common/base/Base.h
+++ b/src/common/base/Base.h
@@ -55,7 +55,14 @@
 #include <folly/String.h>
 #include <folly/Range.h>
 #include <folly/Hash.h>
+
+#if defined(__clang__) && defined(__aarch64__)
+#if FOLLY_HAVE_EXTRANDOM_SFMT19937
+#undef FOLLY_HAVE_EXTRANDOM_SFMT19937
+#endif
+#endif  // __clang__ && __aarch64__
 #include <folly/Random.h>
+
 #include <folly/Conv.h>
 #include <folly/Unicode.h>
 #include <folly/ThreadLocal.h>

--- a/src/common/datatypes/test/EdgeBenchmark.cpp
+++ b/src/common/datatypes/test/EdgeBenchmark.cpp
@@ -9,9 +9,8 @@
 #include <vector>
 
 #include <folly/Benchmark.h>
-#include <folly/Random.h>
-#include <folly/String.h>
 
+#include "common/base/Base.h"
 #include "common/datatypes/Edge.h"
 #include "common/datatypes/Value.h"
 

--- a/src/common/datatypes/test/ValueBenchmark.cpp
+++ b/src/common/datatypes/test/ValueBenchmark.cpp
@@ -9,8 +9,8 @@
 #include <vector>
 
 #include <folly/Benchmark.h>
-#include <folly/Random.h>
 
+#include "common/base/Base.h"
 #include "common/datatypes/Edge.h"
 #include "common/datatypes/Value.h"
 #include "common/datatypes/Vertex.h"

--- a/src/common/time/test/TimeUtilsTest.cpp
+++ b/src/common/time/test/TimeUtilsTest.cpp
@@ -4,9 +4,9 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
-#include <folly/Random.h>
 #include <gtest/gtest.h>
 
+#include "common/base/Base.h"
 #include "common/time/TimeUtils.h"
 
 namespace nebula {


### PR DESCRIPTION
Build fails in arm64 box with clang. It involves folly, clang, gcc and arm neon. So it's complicated. This patch is kind of a workaround.