### PR TITLE
fix and simplify SubscriptRangeExpression's eval()

### DIFF
--- a/src/common/expression/test/SubscriptExpressionTest.cpp
+++ b/src/common/expression/test/SubscriptExpressionTest.cpp
@@ -301,6 +301,15 @@ TEST_F(SubscriptExpressionTest, ListSubscriptRange) {
         EXPECT_TRUE(value.isList());
         EXPECT_EQ(List(), value.getList());
     }
+    // [0,1,2,3,4,5][-2..] => [4,5]
+    {
+        auto *lo = ConstantExpression::make(&pool, -2);
+        auto *hi = ConstantExpression::make(&pool, 3);
+        auto expr = SubscriptRangeExpression::make(&pool, list->clone(), lo, hi);
+        auto value = Expression::eval(expr, gExpCtxt);
+        EXPECT_TRUE(value.isList());
+        EXPECT_EQ(List(), value.getList());
+    }
 }
 
 TEST_F(SubscriptExpressionTest, MapSubscript) {


### PR DESCRIPTION
1. simplify the code;
2. fix the wrong eval for this case:
```
return [0,1,2,3,4,5][-2..]
```
wrong result:
[4]
proper result:
[4,5]